### PR TITLE
add ci checks

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,16 +1,19 @@
 # Documentation https://expeditor.chef.io/docs/getting-started/
 ---
-project:
-  alias: effortless
+github:
+  delete_branch_on_merge: true
 
-slack:
-  notify_channel: effortless-notify
+merge_actions:
+  - trigger_pipeline:habitat/build
 
 pipelines:
   - habitat/build
+  - verify:
+      public: true
+      definition: .expeditor/verify.scaffolding-chef-infra.yml
 
-github:
-  delete_branch_on_merge: true
+project:
+  alias: effortless
 
 promote:
   channels:
@@ -19,5 +22,10 @@ promote:
   actions:
     - built_in:promote_habitat_packages
 
-merge_actions:
-  - trigger_pipeline:habitat/build
+slack:
+  notify_channel: effortless-notify
+
+subscriptions:
+  - workload: pull_request_opened:{{agent_id}}:*
+    actions:
+      - post_github_comment:.expeditor/templates/welcome.mustache

--- a/.expeditor/verify.scaffolding-chef-infra.yml
+++ b/.expeditor/verify.scaffolding-chef-infra.yml
@@ -1,0 +1,52 @@
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
+      retry:
+        automatic:
+          limit: 1
+
+steps:
+  - label: "[scaffolding-chef-infra] :habicat: Check for .bldr.toml entry"
+    command:
+      - bin/ci/check-bldr-toml.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+
+  - label: "[scaffolding-chef-infra] :habicat: Check for bad patterns"
+    command:
+      - bin/ci/check-bad-patterns.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+
+  - label: "[scaffolding-chef-infra] :linux: :habicat: Shellcheck"
+    command:
+      - bin/ci/shellcheck.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+
+  - label: "[scaffolding-chef-infra] :linux: :habicat: Check for default variables"
+    command:
+      - bin/ci/check-default-variables.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+
+  - label: "[scaffolding-chef-infra] :habicat: Check for bad patterns"
+    command:
+      - bin/ci/check-pre-commit.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+
+  - label: "[scaffolding-chef-infra] :linux: :habicat: Build and run tests"
+    command:
+      - bin/ci/build-and-run-tests.sh scaffolding-chef-infra
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    timeout_in_minutes: 60

--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eou pipefail
 
 plan="$(basename "$1")"
 HAB_ORIGIN=ci
@@ -11,13 +11,14 @@ echo "--- :key: Generating fake origin key"
 # we won't have access to any valid signing keys.
 hab origin key generate "$HAB_ORIGIN"
 
+echo "--- :construction: Starting build for $plan"
 # We want to ensure that we build from the project root. This
 # creates a subshell so that the cd will only affect that process
 project_root="$(git rev-parse --show-toplevel)"
 (
   cd "$project_root"
   echo "--- :construction: Building $plan"
-  hab pkg build "$plan"
+  env DO_CHECK=true hab pkg build "$plan"
   source results/last_build.env
   echo "--- :mag: Testing $pkg_ident"
   if [ ! -f "$plan/tests/test.sh" ]; then

--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+plan="$(basename "$1")"
+HAB_ORIGIN=ci
+export HAB_ORIGIN
+
+echo "--- :key: Generating fake origin key"
+# This is intended to be run in the context of public CI where
+# we won't have access to any valid signing keys.
+hab origin key generate "$HAB_ORIGIN"
+
+# We want to ensure that we build from the project root. This
+# creates a subshell so that the cd will only affect that process
+project_root="$(git rev-parse --show-toplevel)"
+(
+  cd "$project_root"
+  echo "--- :construction: Building $plan"
+  hab pkg build "$plan"
+  source results/last_build.env
+  echo "--- :mag: Testing $pkg_ident"
+  if [ ! -f "$plan/tests/test.sh" ]; then
+    buildkite-agent annotate --style 'warning' ":warning: :linux: ${plan} has no Linux tests to run. This is currently permitted but please consider adding some tests."
+    # TODO: At some point, change this to 1 and hard fail the build
+    exit 0
+  fi
+  # Need to rename the studio because studios cannot be re-entered due to umount issues.
+  # Ref: https://github.com/habitat-sh/habitat/issues/6577
+  hab studio -q -r "/hab/studios/verify-build-$pkg_name-$pkg_version-$pkg_release" run "./$plan/tests/test.sh $pkg_ident"
+)

--- a/bin/ci/check-bad-patterns.sh
+++ b/bin/ci/check-bad-patterns.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+plan_path=$1
+
+hab_usage=()
+sleep_usage=()
+exit_code=0
+
+# Until the following PRs land, we cannot sleep in a lifecycle hook
+# with the exception of 'run'
+# habitat-sh/habitat#5954
+# habitat-sh/habitat#5955
+# habitat-sh/habitat#5956
+# habitat-sh/habitat#5957
+# habitat-sh/habitat#5958
+# habitat-sh/habitat#5959
+check_for_sleep() {
+  local file
+
+  file="$1"
+  # Match lines containing `sleep N`, ignoring comments
+  match="^([^#])*sleep [0-9]+"
+
+  if grep -qE "$match" "$file"; then
+    sleep_usage+=("$file")
+    exit_code=1
+  fi
+}
+
+check_for_hab() {
+  local file
+
+  file="$1"
+  # Match anything that looks like we're attempting to call the hab cli
+  # ignoring comments
+  match="^([^#])*(\(\s*|\s+)hab\s"
+  if grep -E -q "$match" "$file"; then
+    hab_usage+=("$file")
+    exit_code=1
+  fi
+}
+
+echo "--- :thinking_face: [$plan_path] Checking for bad patterns"
+readarray -t files < <(find "$plan_path" -type f)
+
+for file in "${files[@]}"; do
+  case $file in
+    */plan.sh | */plan.ps1 )
+      check_for_sleep "$file"
+      ;;
+    *hooks/run )
+      check_for_hab "$file"
+      ;;
+    *hooks/*)
+      check_for_hab "$file"
+      check_for_sleep "$file"
+      ;;
+    **)
+      echo "Skipping $file"
+      ;;
+  esac
+done
+
+if [[ "${#hab_usage[@]}" -ne 0 ]]; then
+  echo "--- :habicat: The following files appear to be calling 'hab'"
+  printf "%s\n" "${hab_usage[@]}"
+fi
+
+if [[ "${#sleep_usage[@]}" -ne 0 ]]; then
+  echo "--- :sleep: The following files appear to be calling 'sleep'"
+  printf "%s\n" "${sleep_usage[@]}"
+fi
+
+if [[ "$exit_code" -eq 0 ]]; then
+  echo "--- :smiling_face: [$plan_path] No bad patterns found!"
+fi
+exit "$exit_code"

--- a/bin/ci/check-bldr-toml.sh
+++ b/bin/ci/check-bldr-toml.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+plan_path="$(basename "$1")"
+
+check_bldr_toml_for() {
+  local plan_name
+  local project_root
+
+  plan_name="$1"
+  project_root=$(git rev-parse --show-toplevel)
+
+  if ! grep -Eq "^\[$plan_name\]" "$project_root"/.bldr.toml
+  then
+    echo "No entry for ${plan_name} in .bldr.toml"
+    exit 1
+  fi
+}
+
+echo "--- :flashlight: [${plan_path}] Checking for .bldr.toml entry"
+check_bldr_toml_for "$plan_path"
+echo "--- :card_index_dividers: Found [${plan_path}] Found .bldr.toml entry"

--- a/bin/ci/check-default-variables.sh
+++ b/bin/ci/check-default-variables.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+  pkg_description
+  pkg_license
+  pkg_maintainer
+  pkg_name
+  pkg_origin
+  pkg_upstream_url
+)
+
+plan_path="$1"
+
+retval=0
+
+echo "--- :open_book: [$plan_path] Checking for default variables"
+for var in "${required_variables[@]}"; do
+  if ! grep -Eq "^$var" "$plan_path/plan.sh"; then
+    echo "    Unable to find '$var' in $*"
+    retval=1
+  fi
+done
+
+
+if [[ $retval -ne 0 ]]; then
+  echo "--- :octogonal_sign: Missing required variables"
+  echo "Ensure that your plan.sh contains all of:"
+  IFS=$'\n'; echo "${required_variables[*]}"
+else
+  echo "--- :closed_book: [$plan_path] Found all default variables"
+fi
+
+exit $retval

--- a/bin/ci/check-pre-commit.sh
+++ b/bin/ci/check-pre-commit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+plan_path="$(basename "$1")"
+
+echo "--- :python: Install pre-commit"
+if [[ "${CI:-}" == "true" ]]; then
+  apt update
+  apt install -y python3-pip
+  pip3 install pre-commit
+else
+  echo "Not in CI! Skipping installation of pre-commit. Please install it manually if executing this on your workstation"
+fi
+pre-commit --version
+
+echo "--- :git: [${plan_path}] Running checks provided by pre-commit hooks"
+find "$plan_path" -type f -print0 | xargs -0 pre-commit run --files

--- a/bin/ci/shellcheck.sh
+++ b/bin/ci/shellcheck.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Run shellcheck against any files that appear to be shell script based on
+# filename or `file` output
+# Exclude *.ps1 files because shellcheck doesn't support them
+# Exclude hooks and config because the handlebars syntax confuses shellcheck
+# Exclude the following shellcheck issues since they're pervasive and innocuous:
+# https://github.com/koalaman/shellcheck/wiki/SC1090
+# https://github.com/koalaman/shellcheck/wiki/SC1091
+# https://github.com/koalaman/shellcheck/wiki/SC1117
+# https://github.com/koalaman/shellcheck/wiki/SC2034
+# https://github.com/koalaman/shellcheck/wiki/SC2039
+# https://github.com/koalaman/shellcheck/wiki/SC2140
+# https://github.com/koalaman/shellcheck/wiki/SC2148
+# https://github.com/koalaman/shellcheck/wiki/SC2153
+# https://github.com/koalaman/shellcheck/wiki/SC2154
+# https://github.com/koalaman/shellcheck/wiki/SC2164
+
+SHELLCHECK_IGNORE="SC1090,SC1091,SC1117,SC2034,SC2039,SC2140,SC2148,SC2153,SC2154,SC2164"
+
+plan_path="$1"
+
+echo "--- :bash: [$plan_path] Running shellcheck"
+
+# Record what version of shellcheck we used in this CI run
+shellcheck --version
+
+find "$plan_path" -type f \
+  -and \( -name "*.*sh" \
+      -or -exec sh -c 'file -b "$1" | grep -q "shell script"' -- {} \; \) \
+  -and \! -path "*.ps1" \
+  -and \! -path "$plan_path/hooks/*" \
+  -and \! -path "$plan_path/config/*" \
+  -print0 \
+  | xargs -0 shellcheck --external-sources --exclude="${SHELLCHECK_IGNORE}"
+
+# shellcheck disable=SC2181
+if [[ $? -eq 0 ]]; then
+  echo "--- :shell: [$plan_path] Shellcheck run successful"
+fi


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

The intent behind this PR is to add CI to this repository.

This CI is pulled straight out of the Habitat core-plans. This allows us to do several things:

1. We can offer a consistent CI experience between different Chef & Community maintained repositories.

2. We can use this repository as a way to test CI changes in "production" before merging the same changes to core-plans. Since core-plans is a much larger project, this can be beneficial for that project as well.

3. We can discover weaknesses in the CI and submit fixes to core-plans.

Additionally this sets us up for testing in the near future. <3