### PR TITLE
[scaffolding-chef-infra] fix policyfile path issues

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -2,8 +2,8 @@
 # A scaffolding for Chef Policyfile packages
 #
 
-if (!$scaffold_policy_name) {
-    Write-Host "You must set `$scaffold_policy_name to a valid policy name. For example:`n `$scaffold_policy_name=base `n Will build a base.rb policyfile."
+if(!$scaffold_policy_name) {
+    Write-Error "You must set `$scaffold_policy_name to a valid policy name. `nTry: `$scaffold_policy_name=example"
     exit 1
 }
 
@@ -71,11 +71,15 @@ while(`$true){
 
 
 function Invoke-DefaultBuild {
-    if (!(Test-Path -Path "$scaffold_policyfile_path")) {
-        Write-BuildLine "Could not detect a policyfile directory, this is required to proceed!"
+    $scaffold_policyfile_path = "$PLAN_CONTEXT\..\policyfile"
+    if([string]::IsNullOrWhiteSpace("$scaffold_policyfile_path")){
+        Write-Error "`$scaffolding_policyfile_path is null, empty string, or white space."
         exit 1
     }
-
+    if(!(Test-Path -Path "$scaffold_policyfile_path")) {
+        Write-Error "`$scaffolding_policy_path is not a valid path."
+        exit 1
+    }
     Remove-Item "$scaffold_policyfile_path/*.lock.json" -Force
     $policyfile = "$scaffold_policyfile_path/$scaffold_policy_name.rb"
 


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

This resolves an issue where the default `scaffold_policyfile_path` was null or empty and not getting set correctly.

I've also provided better error handling and improvements to the error strings.

Original error:

```
Test-Path : Cannot bind argument to parameter 'Path' because it is an empty string.
At C:\hab\pkgs\echohack\scaffolding-chef-infra\0.6.0\20190709120417\lib\scaffolding.ps1:77 char:27
+     if (!(Test-Path -Path "$scaffold_policyfile_path")) {
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidData: (:) [Test-Path], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand
```

New friendly error message:
```
Invoke-DefaultBuild : $scaffolding_policyfile_path is null, empty string, or white space.
At C:\hab\pkgs\core\hab-studio\0.81.0\20190507232342\bin\hab-plan-build.ps1:1205 char:5
+     Invoke-DefaultBuild
+     ~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Invoke-DefaultBuild
```
