### PR TITLE
Fix export of policy archive on windows and fix directory creation

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -93,11 +93,13 @@ function Invoke-DefaultBuild {
 }
 
 function Invoke-DefaultInstall {
+    $scaffold_policyfile_path = "$PLAN_CONTEXT\..\policyfiles"
     Write-BuildLine "Exporting Chef Infra Repository"
     chef export "$scaffold_policyfile_path/$scaffold_policy_name.lock.json" "$pkg_prefix"
 
     Write-BuildLine "Creating Chef Infra configuration"
-    New-Item -ItemType directory -Path "$pkg_prefix/.chef"
+
+    New-Item -ItemType directory -Force -Path "$pkg_prefix/.chef"
     New-Item -ItemType directory -Path "$pkg_prefix/config"
     Add-Content -Path "$pkg_prefix/.chef/config.rb" -Value @"
 cache_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$pkg_svc_data_path/cache").Replace("\","/"))"


### PR DESCRIPTION
This PR fixes two minor issues:
* The Invoke-DefaultInstall method was unable to see the scaffold_policyfile_path variable it needed, which has now been added to that method
* If the .chef directory already existed, plan build would fail when attempting to create it - switched dir creation to use -Force parameter

The missing variable issue was preventing the "chef export" command from producing a policy archive, which - although it did not cause the hab build to fail - produced a package which was missing the policy archive it needs to run.

Signed-off-by: Jon Cowie <jonlives@gmail.com>
