### PR TITLE
fixing readme to have correct key for automate server_url on infra scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ssl_verify_mode = ":verify_peer"
 
 [automate]
 enable = false
-url = "https://<automate_url>"
+server_url = "https://<automate_url>"
 token = "<automate_token>"
 ```
 

--- a/docs/examples/linux-hardening/habitat/default.toml
+++ b/docs/examples/linux-hardening/habitat/default.toml
@@ -11,5 +11,5 @@ ssl_verify_mode = ":verify_peer"
 
 [automate]
 enable = "false"
-url = "https://<automate_url>"
+server_url = "https://<automate_url>"
 token = "<automate_token>"

--- a/docs/examples/windows-hardening/habitat/default.toml
+++ b/docs/examples/windows-hardening/habitat/default.toml
@@ -11,5 +11,5 @@ ssl_verify_mode = ":verify_peer"
 
 [automate]
 enable = "false"
-url = "https://<automate_url>"
+server_url = "https://<automate_url>"
 token = "<automate_token>"


### PR DESCRIPTION

the example shows a key of `url` but that should be `server_url` according to this...

https://github.com/chef/effortless/blob/master/scaffolding-chef-infra/lib/scaffolding.sh#L145

Signed-off-by: Scott Ford <scott@scottford.io>