### PR TITLE
[scaffolding-chef-infra] fix default varible setting

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -43,20 +43,40 @@ function Invoke-DefaultBuildService {
     New-Item -ItemType directory -Path "$pkg_prefix/hooks"
 
     Add-Content -Path "$pkg_prefix/hooks/run" -Value @"
-`$env:CFG_ENV_PATH_PREFIX="{{cfg.env_path_prefix}}"
-if(!`$env:CFG_ENV_PATH_PREFIX) { `$env:CFG_ENV_PATH_PREFIX = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin" }
-`$env:CFG_INTERVAL={{cfg.interval}}
-if(!`$env:CFG_INTERVAL) { `$env:CFG_INTERVAL = 1800 }
-`$env:CFG_LOG_LEVEL="{{cfg.log_level}}"
-if(!`$env:CFG_LOG_LEVEL) { `$env:CFG_LOG_LEVEL = "warn" }
-`$env:CFG_RUN_LOCK_TIMEOUT={{cfg.run_lock_timeout}}
-if(!`$env:CFG_RUN_LOCK_TIMEOUT) { `$env:CFG_RUN_LOCK_TIMEOUT = 1800 }
-`$env:CFG_SPLAY={{cfg.splay}}
-if(!`$env:CFG_SPLAY) { `$env:CFG_SPLAY = 1800 }
-`$env:CFG_SPLAY_FIRST_RUN={{cfg.splay_first_run}}
-if(!`$env:CFG_SPLAY_FIRST_RUN) { `$env:CFG_SPLAY_FIRST_RUN = 0 }
-`$env:CFG_SSL_VERIFY_MODE="{{cfg.ssl_verify_mode}}"
-if(!`$env:CFG_SSL_VERIFY_MODE) { `$env:CFG_SSL_VERIFY_MODE = "verify_peer" }
+`$env:CFG_ENV_PATH_PREFIX = "{{cfg.env_path_prefix}}"
+if(!`$env:CFG_ENV_PATH_PREFIX){
+    `$env:CFG_ENV_PATH_PREFIX = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
+}
+
+`$env:CFG_INTERVAL = "{{cfg.interval}}"
+if(!`$env:CFG_INTERVAL){
+    `$env:CFG_INTERVAL = "1800"
+}
+
+`$env:CFG_LOG_LEVEL = "{{cfg.log_level}}"
+if(!`$env:CFG_LOG_LEVEL){
+    `$env:CFG_LOG_LEVEL = "warn"
+}
+
+`$env:CFG_RUN_LOCK_TIMEOUT = "{{cfg.run_lock_timeout}}"
+if(!`$env:CFG_RUN_LOCK_TIMEOUT){
+    `$env:CFG_RUN_LOCK_TIMEOUT = "1800"
+}
+
+`$env:CFG_SPLAY = "{{cfg.splay}}"
+if(!`$env:CFG_SPLAY){
+    `$env:CFG_SPLAY = "1800"
+}
+
+`$env:CFG_SPLAY_FIRST_RUN = "{{cfg.splay_first_run}}"
+if(!`$env:CFG_SPLAY_FIRST_RUN){
+    `$env:CFG_SPLAY_FIRST_RUN = "0"
+}
+
+`$env:CFG_SSL_VERIFY_MODE = "{{cfg.ssl_verify_mode}}"
+if(!`$env:CFG_SSL_VERIFY_MODE){
+    `$env:CFG_SSL_VERIFY_MODE = "verify_peer"
+}
 
 function Invoke-ChefClient {
   {{pkgPathFor "stuartpreston/chef-client"}}/bin/chef-client.bat -z -l `$env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout `$env:CFG_RUN_LOCK_TIMEOUT


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

This PR provides a fix for a subtle bug we discovered with how default variables get set in the Windows version of `scaffolding-chef-infra`.

Essentially, if the default.toml is set, but certain values are not overwritten, then those values will fallback to the defaults set in the run hook `$env:CFG_*` variables. However, Powershell requires all variables set to be enclosed in quotes, or else they will not set correctly.

This also fixes formatting a bit in order to make this section easier to read.

Error Log:

```
2019-07-16 14:57:21,145 - base-windows.default(O): Compiling Cookbooks...[0m
2019-07-16 14:57:21,148 - base-windows.default(O): Converging 0 resources[0m
2019-07-16 14:57:21,164 - base-windows.default(O): [0m
2019-07-16 14:57:21,165 - base-windows.default(O): Running handlers:[0m
2019-07-16 14:57:21,165 - base-windows.default(O): Running handlers complete
2019-07-16 14:57:21,165 - base-windows.default(O): [0mChef Client finished, 0/0 resources updated in 08 seconds[0m
2019-07-16 15:08:01,135 - hab-sup(SU): Updating from origin/base-windows/0.1.0/20190716214528 to origin/base-windows/0.1.0/20190716215727
2019-07-16 15:08:01,472 - hab-sup(MR): Updating from origin/base-windows to origin/base-windows/0.1.0/20190716215727
2019-07-16 15:08:01,472 - base-windows.default(ST): Terminating service (PID: 7588)
2019-07-16 15:08:01,474 - base-windows.default(SR): Health checking has been stopped
2019-07-16 15:08:01,529 - base-windows.default(ST): Service gracefully terminated (PID: 7588)
2019-07-16 15:08:01,612 - hab-launch(SV): Child for service 'base-windows.default' with PID 7588 exited with code exit code: 1
2019-07-16 15:08:02,513 - hab-sup(MR): Starting origin/base-windows (origin/base-windows/0.1.0/20190716215727)
2019-07-16 15:08:02,519 - base-windows.default(UCW): Watching user.toml
2019-07-16 15:08:02,524 - base-windows.default(HK): Modified hook content in C:\hab\svc\base-windows\hooks\run
2019-07-16 15:08:02,536 - base-windows.default(SR): Hooks recompiled
2019-07-16 15:08:02,548 - base-windows.default(CF): Modified configuration file C:\hab\svc\base-windows\config\client-config.rb
2019-07-16 15:08:02,549 - base-windows.default(SR): Initializing
2019-07-16 15:08:02,549 - base-windows.default(SV): Starting service as user=seasfvstswv10$, group=<anonymous>
2019-07-16 15:08:19,663 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:08:19,664 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:08:19,883 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:08:19,883 - base-windows.default(E): At line:33 char:24
2019-07-16 15:08:19,883 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:08:19,883 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:08:19,884 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:08:19,884 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:08:19,884 - base-windows.default(E):  
2019-07-16 15:08:33,901 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:08:33,901 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:08:33,926 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:08:33,927 - base-windows.default(E): At line:33 char:24
2019-07-16 15:08:33,927 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:08:33,927 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:08:33,927 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:08:33,927 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:08:33,927 - base-windows.default(E):  
2019-07-16 15:08:46,727 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:08:46,727 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:08:46,727 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:08:46,728 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:08:46,728 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:08:46,728 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:08:46,728 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:08:46,728 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:08:46,756 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:08:46,756 - base-windows.default(E): At line:33 char:24
2019-07-16 15:08:46,756 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:08:46,757 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:08:46,757 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:08:46,757 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:08:46,757 - base-windows.default(E):  
2019-07-16 15:09:01,880 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:09:01,880 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:09:01,881 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:09:01,913 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:09:01,913 - base-windows.default(E): At line:33 char:24
2019-07-16 15:09:01,913 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:09:01,913 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:09:01,913 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:09:01,913 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:09:01,913 - base-windows.default(E):  
2019-07-16 15:09:16,848 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:09:16,848 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:09:16,886 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:09:16,886 - base-windows.default(E): At line:33 char:24
2019-07-16 15:09:16,886 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:09:16,886 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:09:16,886 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:09:16,886 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:09:16,886 - base-windows.default(E):  
2019-07-16 15:09:31,400 - base-windows.default(E): C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/mixlib-cli-1.7.0/lib/mixlib/cli.rb:230:in `parse_options': missing argument: --run-lock-timeout (OptionParser::MissingArgument)
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:96:in `configure_chef'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:55:in `reconfigure'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application/client.rb:313:in `reconfigure'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/lib/chef/application.rb:64:in `run'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/lib/ruby/gems/2.6.0/gems/chef-14.11.21/bin/chef-client:25:in `<top (required)>'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `load'
2019-07-16 15:09:31,400 - base-windows.default(E): 	from C:/hab/pkgs/stuartpreston/chef-client/14.11.21/20190328012639/bin/chef-client:23:in `<main>'
2019-07-16 15:09:31,430 - base-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-16 15:09:31,430 - base-windows.default(E): At line:33 char:24
2019-07-16 15:09:31,430 - base-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-16 15:09:31,430 - base-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-16 15:09:31,430 - base-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
2019-07-16 15:09:31,430 - base-windows.default(E): + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.PowerShell.Commands.StartSleepCommand
2019-07-16 15:09:31,430 - base-windows.default(E):  
```