### PR TITLE
Add windows build target for InSpec scaffolding

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -9,5 +9,6 @@ build_targets = [
 plan_path = "scaffolding-chef-inspec"
 build_targets = [
   "x86_64-linux",
-  "x86_64-linux-kernel2"
+  "x86_64-linux-kernel2",
+  "x86_64-windows"
 ]


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This adds Windows to the build targets so we can get automated builds of the windows scaffolding for InSpec

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
