### PR TITLE
[scaffolding-chef-inspec] fix left out interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ interval = 1800
 splay = 1800
 splay_first_run = 0
 log_level = 'warn'
-report_to_stdout = true
 
 [chef_license]
 acceptance = "undefined"

--- a/scaffolding-chef-inspec/lib/scaffolding.ps1
+++ b/scaffolding-chef-inspec/lib/scaffolding.ps1
@@ -52,6 +52,7 @@ if(!`$env:CFG_SPLAY_FIRST_RUN) {
 
 `$env:CFG_INTERVAL="{{cfg.interval}}"
 if(!`$env:CFG_INTERVAL){
+    `$env:CFG_INTERVAL = "1800"
 }
 
 `$env:CFG_SPLAY="{{cfg.splay}}"
@@ -120,7 +121,7 @@ function Invoke-DefaultInstall {
     "target_id": "{{ sys.member_id }}",
     "reporter": {
         "cli": {
-          "stdout": {{cfg.report_to_stdout}}
+          "stdout": true
         },
         "json": {
           "file": "{{pkg.svc_path}}/logs/inspec_last_run.json"
@@ -152,7 +153,6 @@ interval = 1800
 splay = 1800
 splay_first_run = 0
 log_level = 'warn'
-report_to_stdout = true
 
 [chef_license]
 acceptance = "undefined"

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -135,7 +135,7 @@ EOF
     "target_id": "{{ sys.member_id }}",
     "reporter": {
       "cli": {
-        "stdout": {{cfg.report_to_stdout}}
+        "stdout": true
       },
       "json": {
         "file": "{{pkg.svc_path}}/logs/inspec_last_run.json"
@@ -167,7 +167,6 @@ interval = 1800
 splay = 1800
 splay_first_run = 0
 log_level = 'warn'
-report_to_stdout = true
 
 [chef_license]
 acceptance = "undefined"


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

I feel really bad for missing this in my code review. I think this just highlights the problem of having heredocs in the scaffolding...I want to work soon on building things in separate files.

Here's the kind of error you receive when this isn't defined:

```

2019-07-18 17:35:36,420 - audit-windows.default(E): Start-Sleep : Cannot validate argument on parameter 'Seconds'. The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.
2019-07-18 17:35:36,420 - audit-windows.default(E): At line:45 char:24
2019-07-18 17:35:36,420 - audit-windows.default(E): +   Start-Sleep -Seconds $env:CFG_INTERVAL
2019-07-18 17:35:36,420 - audit-windows.default(E): +                        ~~~~~~~~~~~~~~~~~
2019-07-18 17:35:36,420 - audit-windows.default(E): + CategoryInfo          : InvalidData: (:) [Start-Sleep], ParameterBindingValidationException
```

This also fixes the same problem with `report_to_stdout`. We should set this to true always -- unless we have a very good reason for exposing this configuration value. If we do decide to make this a configurable API in the future, it should be done the same for both Chef and InSpec.