### PR TITLE
Paths are only created if they do not exist

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -40,7 +40,12 @@ function Invoke-SetupEnvironment {
 
 function Invoke-DefaultBuildService {
     Write-BuildLine "Creating lifecycle hooks"
-    New-Item -ItemType directory -Path "$pkg_prefix/hooks"
+
+    # Only create the directory if it does not exist
+    $dir = "$pkg_prefix/hooks"
+    if (!(Test-Path -Path $dir)) {
+        New-Item -ItemType directory -Path $dir
+    }
 
     Add-Content -Path "$pkg_prefix/hooks/run" -Value @"
 `$env:CFG_ENV_PATH_PREFIX = "{{cfg.env_path_prefix}}"
@@ -131,8 +136,16 @@ function Invoke-DefaultInstall {
 
     Write-BuildLine "Creating Chef Infra configuration"
 
-    New-Item -ItemType directory -Force -Path "$pkg_prefix/.chef"
-    New-Item -ItemType directory -Path "$pkg_prefix/config"
+    $dir = "$pkg_prefix/.chef"
+    if (!(Test-Path -Path $dir)) {
+        New-Item -ItemType directory -Path $dir
+    }
+
+    $dir = "$pkg_prefix/config"
+    if (!(Test-Path -Path $dir)) {
+        New-Item -ItemType directory -Path $dir
+    }
+
     Add-Content -Path "$pkg_prefix/.chef/config.rb" -Value @"
 cache_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$pkg_svc_data_path/cache").Replace("\","/"))"
 node_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$pkg_svc_data_path/nodes").Replace("\","/"))"


### PR DESCRIPTION
## Description
When building a Habitat package in a fresh studio errors are thrown about directories already existing in the `$pkg_prefix` directory.

## Related Issue
https://github.com/chef/effortless/issues/76

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
