### PR TITLE
Removing the "compliance" section in the InSpec config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ interval = 1800
 splay = 1800
 splay_first_run = 0
 log_level = 'warn'
+report_to_stdout = true
 
 [chef_license]
 acceptance = "undefined"

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -141,20 +141,12 @@ EOF
         "file": "{{pkg.svc_path}}/logs/inspec_last_run.json"
       }{{#if cfg.automate.enable ~}},
       "automate" : {
-        "url": "{{cfg.automate.server_url}}/data-collector/v0/",
+        "url": "{{cfg.automate.server_url}}",
         "token": "{{cfg.automate.token}}",
         "node_name": "{{ sys.hostname }}",
         "verify_ssl": false
       }{{/if ~}}
     }
-    {{#if cfg.automate.enable }},
-    "compliance": {
-     "server" : "{{cfg.automate.server_url}}",
-     "token" : "{{cfg.automate.token}}",
-     "user" : "{{cfg.automate.user}}",
-     "insecure" : true,
-     "ent" : "automate"
-    }{{/if }}
 }
 EOF
   chmod 0640 "$pkg_prefix/config/inspec_exec_config.json"
@@ -167,6 +159,7 @@ interval = 1800
 splay = 1800
 splay_first_run = 0
 log_level = 'warn'
+report_to_stdout = true
 
 [chef_license]
 acceptance = "undefined"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The compliance section int the InSpec config is causing the InSpec exec to fail. With the section I am seeing the below error. 
```
whale-server-tests.default(O): /hab/pkgs/core/ruby/2.5.5/20190416223112/lib/ruby/2.5.0/json/common.rb:156:in `parse': 765: unexpected token at 'ok (JSON::ParserError)
whale-server-tests.default(O): '
whale-server-tests.default(O): 	from /hab/pkgs/core/ruby/2.5.5/20190416223112/lib/ruby/2.5.0/json/common.rb:156:in `parse'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/plugins/inspec-compliance/lib/inspec-compliance/api.rb:110:in `version'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb:171:in `compliance_store_access_token'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb:129:in `login'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/plugins/inspec-compliance/lib/inspec-compliance/api/login.rb:24:in `login'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/config.rb:436:in `finalize_compliance_login'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/config.rb:366:in `finalize_options'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/config.rb:57:in `initialize'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/base_cli.rb:239:in `new'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/base_cli.rb:239:in `config'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/cli.rb:290:in `exec'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-4.7.18/lib/inspec/base_cli.rb:33:in `start'
whale-server-tests.default(O): 	from /hab/pkgs/chef/inspec/4.7.18/20190718014843/lib/gems/inspec-bin-4.7.18/bin/inspec:11:in `<main>'
```
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
