### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cookbook 'tar'
 cookbook 'os-hardening'
 
 run_list [
-  'hardening::default', 'example-app::default'
+  'os-hardening::default', 'example-app::default'
 ]
 ```
 


### PR DESCRIPTION
There is no `hardening` cookbook, it is called `os-hardening`.

This fixes the following error message:
```
Error: Failed to generate Policyfile.lock
Reason: (Solve::Errors::NoSolutionError) Unable to satisfy the following requirements:

- hardening (>= 0.0.0)` required by `user-specified dependency`
```

