### PR TITLE
Make Terraform version pinning pessimistic

### DIFF
--- a/examples/terraform/aws-centos7/main.tf
+++ b/examples/terraform/aws-centos7/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "> 0.11.0"
+  required_version = "~> 0.11.0"
 }
 
 provider "aws" {

--- a/examples/terraform/aws-windows2016/main.tf
+++ b/examples/terraform/aws-windows2016/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "> 0.11.0"
+  required_version = "~> 0.11.0"
 }
 
 provider "aws" {


### PR DESCRIPTION
The current files do not work on `0.12.0`.

See: https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version
