### PR TITLE
Adds SSL_CERT_DIR environment variable to scaffolding-chef-infra

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -92,6 +92,7 @@ function Invoke-ChefClient {
 `$SPLAY_FIRST_RUN_DURATION = Get-Random -InputObject (0..`$env:CFG_SPLAY_FIRST_RUN) -Count 1
 
 `$env:SSL_CERT_FILE="{{pkgPathFor "$(if(![string]::IsNullOrWhiteSpace("$env:CFG_CACERTS")){$env:CFG_CACERTS} else{'core/cacerts'})"}}/ssl/cert.pem"
+`$env:SSL_CERT_DIR="{{pkgPathFor "$(if(![string]::IsNullOrWhiteSpace("$env:CFG_CACERTS")){$env:CFG_CACERTS} else{'core/cacerts'})"}}/ssl/certs"
 
 cd {{pkg.path}}
 

--- a/scaffolding-chef-infra/lib/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/scaffolding.sh
@@ -86,6 +86,7 @@ SPLAY_DURATION=\$(shuf -i 0-\$CFG_SPLAY -n 1)
 SPLAY_FIRST_RUN_DURATION=\$(shuf -i 0-\$CFG_SPLAY_FIRST_RUN -n 1)
 
 export SSL_CERT_FILE="{{ pkgPathFor "${CFG_CACERTS:-core/cacerts}" }}/ssl/cert.pem"
+export SSL_CERT_DIR="{{ pkgPathFor "${CFG_CACERTS:-core/cacerts}" }}/ssl/certs"
 
 cd {{pkg.path}}
 


### PR DESCRIPTION
Signed-off-by: Nathan Weddle <nathan.weddle@alaskaair.com>

This adds the OpenSSL environment variable `SSL_CERT_DIR` to enable Chef Infra Client to read any custom CA certificates from SSL_CERT_DIR (.../ssl/certs/), in addition to reading the certificate bundle from SSL_CERT_FILE (.../ssl/cert.pem).

This requires that certificates are located in the specified directory, and that their filenames are based on the CA certificate x509 hash value[1].

[1]https://www.openssl.org/docs/manmaster/man1/c_rehash.html