### PR TITLE
ensure windows ps modules are at the front of PSModulesPath

### DIFF
--- a/scaffolding-chef-infra/lib/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/scaffolding.ps1
@@ -151,7 +151,7 @@ cache_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromP
 node_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$pkg_svc_data_path/nodes").Replace("\","/"))"
 role_path "$($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$pkg_svc_data_path/roles").Replace("\","/"))"
 chef_zero.enabled true
-ENV['PSModulePath'] += "C:/Program\ Files/WindowsPowerShell/Modules"
+ENV['PSModulePath'] = "C:/Program\ Files/WindowsPowerShell/Modules;C:/Windows/system32/WindowsPowerShell/v1.0/Modules;#{ENV['PSModulePath']}"
 "@
 
     Write-BuildLine "Creating initial bootstrap configuration"


### PR DESCRIPTION
An interesting problem we have with chef effortless is that we invoke the chef client from Powershell Core (`pwsh.exe`). When in a Powershell Core shell, powershell core prepends the `PSModulesPath` with its own module locations. The `PSModulesPath` acts like `PATH` and tells powershell where to find modules and it will search from the beginning until it finds a qualifying module.

When running powershell or dsc resources inside of the chef client, chef shells out to "Windows Powershell" via `powershell.exe`. Today we add `C:/Program Files/WindowsPowerShell/Modules` which is where user programs typically add their windows powershell modules. Windows powershell internal modules are kept in `C:\Windows\system32\WindowsPowerShell\v1.0\Modules` which ia already on the path but after the ps core module locations.

In most scenarios this should work just fine. However there are some modules with the same name that are in both windows powershell and ps core module locations. When in windows powershell it is important the the windows powershell modules are the one that are used. One of these modules is `PSDesiredStateConfiguration` so when chef calls `Get-DSCResource` or `Get-DSCResourceModule`, it is currently using the ps core module which will simply break.

This PR ensures that the common windows powershell module locations are at the front of `PSModulesPath` in a chef run so that the windows modules are given precedence over ps core.

Signed-off-by: mwrock <matt@mattwrock.com>

