### PR TITLE
Modify kitchen.yml to use Habitat + tar

### DIFF
--- a/examples/infra-linux-policyfile-cookbook/kitchen.yml
+++ b/examples/infra-linux-policyfile-cookbook/kitchen.yml
@@ -14,6 +14,12 @@ verifier:
 platforms:
   - name: ubuntu-16.04
 
+lifecycle:
+  pre_create:
+    # Export archive as a tar (removes need to install hab and pull/transfer keys)
+    # This is done in the studio since export as tar is only supported on Linux
+    - hab studio run 'cd results && source last_build.env && hab pkg export tar $pkg_artifact && mv $pkg_origin-$pkg_name-$pkg_version-$pkg_release.tar.gz hab_artifact.tar.gz'
+
 suites:
   - name: default
     verifier:


### PR DESCRIPTION
This does the following:
  - Removes need for origin public keys to be on Builder
  - Standardizes workflow with other examples (e.g Terraform)
  - Removes need for Habitat install (saves bandwidth)

