### PR TITLE
Fix issue with Linux Automate profile dependencies

### DIFF
--- a/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/controls/example.rb
+++ b/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/controls/example.rb
@@ -1,0 +1,5 @@
+title 'CIS Automate Test'
+
+include_controls 'cis-rhel7-level1-server' do
+  skip_control 'xccdf_org.cisecurity.benchmarks_rule_1.1.14_Ensure_nodev_option_set_on_home_partition'
+end

--- a/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/habitat/plan.sh
@@ -1,0 +1,7 @@
+pkg_name=effortless-a2-profile-test
+pkg_version=1.0.0
+pkg_origin=chef
+pkg_scaffolding="chef/scaffolding-chef-inspec"
+scaffold_automate_server_url=$AUTOMATE_SERVER_URL # Example: https://foo.bar.com
+scaffold_automate_user=$AUTOMATE_USER             # Example: "admin"
+scaffold_automate_token=$AUTOMATE_TOKEN           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="

--- a/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/inspec.yml
+++ b/scaffolding-chef-inspec/tests/linux/user-a2-profile-dep/inspec.yml
@@ -1,0 +1,7 @@
+name: effortless-a2-profile-test
+title: Effortless Automate CIS profile Test
+version: 1.0.0
+
+depends:
+  - name: cis-rhel7-level1-server
+    compliance: admin/cis-rhel7-level1-server


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

Fix #117 
When attempting to pull a profile dependency from Automate there was a parsing error with jq. This change brings the scaffolding in line with the update made to Windows scaffolding and provides an API for users to put in their Automate credentials.
