### PR TITLE
[scaffolding-chef-inspec] add cacerts for inspec

### DIFF
--- a/scaffolding-chef-inspec/lib/scaffolding.ps1
+++ b/scaffolding-chef-inspec/lib/scaffolding.ps1
@@ -3,10 +3,18 @@
 #
 
 function Load-Scaffolding {
+    $scaffold_cacerts = ""
+
     $pkg_deps += @(
         "${pkg_deps[@]}"
         "stuartpreston/inspec"
     )
+    if(![string]::IsNullOrWhiteSpace("$scaffold_cacerts")){
+        $pkg_deps += @($scaffold_cacerts)
+    } else{
+        $pkg_deps += @("core/cacerts")
+    }
+
     $pkg_build_deps += @(
         "${pkg_build_deps[@]}"
         "stuartpreston/inspec"
@@ -65,6 +73,8 @@ function Invoke-DefaultBuildService {
     New-Item -ItemType Directory -Path "$pkg_prefix/hooks"
 
     Add-Content -Path "$pkg_prefix/hooks/run" -Value @"
+`$env:SSL_CERT_FILE="{{pkgPathFor "$(if(![string]::IsNullOrWhiteSpace("$env:CFG_CACERTS")){$env:CFG_CACERTS} else{'core/cacerts'})"}}/ssl/cert.pem"
+`$env:SSL_CERT_DIR="{{pkgPathFor "$(if(![string]::IsNullOrWhiteSpace("$env:CFG_CACERTS")){$env:CFG_CACERTS} else{'core/cacerts'})"}}/ssl/certs"
 `$env:PATH = "{{pkgPathFor "stuartpreston/inspec"}}/bin;`$env:PATH"
 
 `$env:CFG_SPLAY_FIRST_RUN="{{cfg.splay_first_run}}"

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -6,11 +6,18 @@ scaffolding_load() {
   : "${scaffold_automate_server_url:=}"
   : "${scaffold_automate_user:=}"
   : "${scaffold_automate_token:=}"
+  : "${scaffold_cacerts:=}"
 
   pkg_deps=(
     "${pkg_deps[@]}"
     "chef/inspec"
   )
+  if [ -n "${scaffold_cacerts}" ]; then
+    pkg_deps+=("${scaffold_cacerts}")
+  else
+    pkg_deps+=("core/cacerts")
+  fi
+
   pkg_build_deps=(
     "${pkg_build_deps[@]}"
     "chef/inspec"
@@ -94,6 +101,8 @@ do_default_build_service() {
 
 export HOME="{{pkg.svc_var_path}}"
 export INSPEC_CONFIG_DIR="{{pkg.svc_var_path}}"
+export SSL_CERT_FILE="{{ pkgPathFor "${CFG_CACERTS:-core/cacerts}" }}/ssl/cert.pem"
+export SSL_CERT_DIR="{{ pkgPathFor "${CFG_CACERTS:-core/cacerts}" }}/ssl/certs"
 
 CFG_SPLAY_FIRST_RUN={{cfg.splay_first_run}}
 CFG_SPLAY_FIRST_RUN="\${CFG_SPLAY_FIRST_RUN:-0}"

--- a/scaffolding-chef-inspec/tests/linux/user-git-profile-dep/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/linux/user-git-profile-dep/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-inspec/tests/linux/user-git-profile-dep/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/linux/user-git-profile-dep/habitat/plan.sh
@@ -1,8 +1,4 @@
 pkg_name=effortless-audit-baseline
 pkg_version=0.1.0
 pkg_origin=chef
-pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-pkg_license=("Apache-2.0")
-pkg_description="The Audit Baseline InSpec Profile"
-pkg_upstream_url="http://chef.io"
 pkg_scaffolding="chef/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/habitat/plan.ps1
@@ -1,9 +1,6 @@
 $pkg_name="effortless-audit-baseline"
 $pkg_origin="chef"
 $pkg_version="0.1.0"
-$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-$pkg_license=("Apache-2.0")
 $pkg_build_deps=@("stuartpreston/inspec")
 $pkg_deps=@("stuartpreston/inspec")
-$pkg_description="Effortless Windows Audit"
 $pkg_scaffolding="chef/scaffolding-chef-inspec"


### PR DESCRIPTION
Signed-off-by: David Echo <echohack@users.noreply.github.com>

This adds the CACerts feature we added for [scaffolding-chef-infra] for InSpec.

Note that I'm currently working on a refactor that impacts this feature and should make for less surprises in the future regarding pipelining buildtime variables to runtime.

Tested on Windows2016 and Centos7 boxes for both Windows and Linux builds.