### PR TITLE
Fix issue where linux and windows config are different

### DIFF
--- a/examples/inspec-linux-audit/habitat/default.toml
+++ b/examples/inspec-linux-audit/habitat/default.toml
@@ -45,7 +45,7 @@ log_level = "warn"
 #  - user: User for requests to Chef Automate (Default: '<automate_user>')
 [automate]
 enable = false
-server_url = "https://<automate_url>/data-collector/v0/"
+server_url = "https://<automate_url>"
 token = '<automate_token>'
 user = '<automate_user>'
 

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -170,9 +170,6 @@ EOF
     "reporter": {
       "cli": {
         "stdout": true
-      },
-      "json": {
-        "file": "{{pkg.svc_path}}/logs/inspec_last_run.json"
       }{{#if cfg.automate.enable ~}},
       "automate" : {
         "url": "{{cfg.automate.server_url}}/data-collector/v0/",
@@ -181,14 +178,6 @@ EOF
         "verify_ssl": false
       }{{/if ~}}
     }
-    {{#if cfg.automate.enable }},
-    "compliance": {
-     "server" : "{{cfg.automate.server_url}}",
-     "token" : "{{cfg.automate.token}}",
-     "user" : "{{cfg.automate.user}}",
-     "insecure" : true,
-     "ent" : "automate"
-    }{{/if }}
 }
 EOF
   chmod 0640 "$pkg_prefix/config/inspec_exec_config.json"


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

During some troubleshooting for a different issue it was noticed that the config for `inspec_exec_config.json` for Linux was not the same as the Windows config. This will bring the config back to being the same between Linux and Windows and will make troubleshooting issues easier.

#131 