### PR TITLE
Fix issue with include_policy build with single quotes

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -62,4 +62,10 @@ project_root="$(git rev-parse --show-toplevel)"
   fi
 
   hab studio -q -r "/hab/studios/api-${API_PKG_RELEASE}" run "hab pkg install results/${API_PKG_ARTIFACT} && ./${plan}/tests/test.sh ${API_PKG_IDENT}"
+
+  echo "--- :construction: :linux: Building include policy with double quotes user plan"
+  hab studio -q -r "/hab/studios/nested-double-${SCAFFOLDING_PKG_RELEASE}" run "export CHEF_POLICYFILE=double && hab pkg install results/${SCAFFOLDING_PKG_ARTIFACT} && build ${plan}/tests/user-linux-include-policy"
+
+  echo "--- :construction: :linux: Building include policy with single quotes user plan"
+  hab studio -q -r "/hab/studios/nested-single-${SCAFFOLDING_PKG_RELEASE}" run "export CHEF_POLICYFILE=single && hab pkg install results/${SCAFFOLDING_PKG_ARTIFACT} && build ${plan}/tests/user-linux-include-policy"
 )

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -64,6 +64,11 @@ do_default_build() {
   policyfile="${scaffold_policyfile_path}/${scaffold_policy_name}.rb"
 
   for p in $(grep include_policy "${policyfile}" | awk -F "," '{print $1}' | awk -F '"' '{print $2}' | tr -d " "); do
+    build_line "Detected included policyfile, ${p}.rb, installing"
+    chef install "${scaffold_policyfile_path}/${p}.rb"
+  done
+  for p in $(grep include_policy "${policyfile}" | awk -F "," '{print $1}' | awk -F '\x27' '{print $2}' | tr -d " "); do
+    build_line "Detected included policyfile, ${p}.rb, installing"
     chef install "${scaffold_policyfile_path}/${p}.rb"
   done
 

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -68,7 +68,19 @@ function Invoke-DefaultBuild {
 
     Get-Content $policyfile | ? { $_.StartsWith("include_policy") } | % {
         $p = $_.Split()[1]
-        $p = $p.Replace("`"", "").Replace(",", "")
+        if ($p.Contains("'")) {
+            $p = $p.Replace("'", "").Replace(",", "")
+        }
+        elseif($p.Contains("`"")) {
+            $p = $p.Replace("`"", "").Replace(",", "")
+        }
+        else {
+            Write-Buildline "There is a problem in the policyfile with this line"
+            Write-BuildLine "$_"
+            Write-BuildLine "Please fix this before continuing."
+            exit 1
+        }
+        Write-BuildLine "Detected included policyfile, $p.rb, installing"
         chef install "$scaffold_policyfile_path/$p.rb"
     }
     chef install "$policyfile"

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/attributes/default.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/attributes/default.rb
@@ -1,0 +1,2 @@
+default['ci']['single_quote'] = false
+default['ci']['double_quote'] = false

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/metadata.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/metadata.rb
@@ -1,0 +1,2 @@
+name 'ci'
+version '1.0.0'

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/recipes/default.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/cookbooks/ci/recipes/default.rb
@@ -1,0 +1,15 @@
+file '/hab/svc/user-linux-include-policy/test' do
+  content "Hello world!"
+end
+
+if node['ci']['double_quote']
+  file '/hab/svc/user-linux-include-policy/test_double' do
+    content 'Include policy with double quote'
+  end
+end
+
+if node['ci']['single_quote']
+  file '/hab/svc/user-linux-include-policy/test_single' do
+    content 'Include policy with double quote'
+  end
+end

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/default.toml
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/plan.sh
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/plan.sh
@@ -1,0 +1,24 @@
+#######################################
+# User plan for ci testing
+# This tests a user interacting with scaffold API
+#######################################
+
+#@IgnoreInspection BashAddShebang
+if [ -z "${CHEF_POLICYFILE+x}" ]; then
+  policy_name="ci"
+else
+  policy_name="${CHEF_POLICYFILE}"
+fi
+
+pkg_name=user-linux-nested-policy
+pkg_origin=ci
+pkg_version="1.0.0"
+pkg_scaffolding="ci/scaffolding-chef-infra"
+pkg_svc_user=("root")
+scaffold_policy_name="$policy_name"
+
+# Required Metadata for CI
+pkg_description="CI Test Plan for include policy Linux"
+pkg_license="Apache-2.0"
+pkg_maintainer="The Habitat Maintainers humans@habitat.sh"
+pkg_upstream_url="https://chef.sh"

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/ci.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/ci.rb
@@ -1,0 +1,7 @@
+name "ci"
+
+default_source :chef_repo, '../'
+
+run_list [
+  "ci::default",
+]

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/double.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/double.rb
@@ -1,0 +1,9 @@
+name "double"
+
+include_policy "ci", path: "./ci.lock.json"
+
+run_list [
+  "ci::default",
+]
+
+default['ci']['double_quote'] = true

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/single.rb
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/policyfiles/single.rb
@@ -1,0 +1,9 @@
+name "single"
+
+include_policy 'ci', path: "./ci.lock.json"
+
+run_list [
+  "ci::default",
+]
+
+default['ci']['single_quote'] = true


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

#41 

This is an interesting bug if the policyfile includes an `include_policy` but the policy name is in single quotes instead of double quotes it will fail to find the policy and won't build the correct lock file and the build will fail. This adds an additional for loop but looks specifically for a single quote which is represented `x27` to the `awk` command.