### PR TITLE
[scaffolding-chef-infra] use single quotes for ruby string literal

### DIFF
--- a/scaffolding-chef-infra/lib/linux/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/linux/client-chunk.rb
@@ -1,8 +1,8 @@
-cfg_env_path_prefix = {{cfg.env_path_prefix}}
+cfg_env_path_prefix = '{{cfg.env_path_prefix}}'
 cfg_env_path_prefix ||= '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin'
 ENV['PATH'] = "#{cfg_env_path_prefix}:#{ENV['PATH']}"
 
-cfg_ssl_verify_mode = {{cfg.ssl_verify_mode}}
+cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
 cfg_ssl_verify_mode ||= ':verify_peer'
 ssl_verify_mode "#{cfg_env_path_prefix}"
 

--- a/scaffolding-chef-infra/lib/windows/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/windows/client-chunk.rb
@@ -1,8 +1,8 @@
-cfg_env_path_prefix = {{cfg.env_path_prefix}}
+cfg_env_path_prefix = '{{cfg.env_path_prefix}}'
 cfg_env_path_prefix ||= ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
 ENV['PATH'] += cfg_env_path_prefix
 
-cfg_ssl_verify_mode = {{cfg.ssl_verify_mode}}
+cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
 cfg_ssl_verify_mode ||= ":verify_peer"
 ssl_verify_mode "#{cfg_ssl_verify_mode}"
 


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

An obvious improvement to templating out these strings for Ruby files. Thanks to @afiune for bringing this to our attention.