### PR TITLE
Fix issue with license and chef-client in run

### DIFF
--- a/scaffolding-chef-infra/lib/windows/run.ps1
+++ b/scaffolding-chef-infra/lib/windows/run.ps1
@@ -34,11 +34,11 @@ if(!$env:CFG_CHEF_LICENSE){
 if($env:CFG_CHEF_LICENSE -eq "undefined"){
     $env:CFG_CHEF_LICENSE_CMD = ""
 } else {
-    $env:CFG_CHEF_LICENSE_CMD = "--chef-license $env:CFG_CHEF_LICENSE"
+    $env:CFG_CHEF_LICENSE_CMD = "--chef-license '$env:CFG_CHEF_LICENSE'"
 }
 
 function Invoke-ChefClient {
-  {{pkgPathFor "stuartpreston/chef-client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT $env:CFG_CHEF_LICENSE_CMD
+  {{pkgPathFor "scaffold_chef_client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT $env:CFG_CHEF_LICENSE_CMD
 }
 
 $SPLAY_DURATION = Get-Random -InputObject (0..$env:CFG_SPLAY) -Count 1

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -19,8 +19,13 @@ if(!(Test-Path -Path "$scaffold_policyfile_path")) {
     Write-Error "`$scaffold_policy_path is not a valid path."
     exit 1
 }
+# These variables are being set because Load-Scaffolding is not working.
+# When loading gets fixed these can be removed.
 if(!$scaffold_cacerts){
     $scaffold_cacerts = "core/cacerts"
+}
+if(!$scaffold_chef_client){
+    $scaffold_chef_client = "stuartpreston/chef-client"
 }
 
 # Internals
@@ -58,8 +63,10 @@ function Invoke-DefaultBuildService {
         New-Item -ItemType directory -Path $dir
     }
 
-    $run_hook = (Get-Content -Path "$lib_dir/run.ps1") -join "`n"
-    $run_hook -replace 'scaffold_cacerts', $scaffold_cacerts | Add-Content -Path "$pkg_prefix/hooks/run"
+    (Get-Content -Path "$lib_dir/run.ps1") -join "`n" | Foreach-Object {
+        $_ -replace 'scaffold_cacerts', $scaffold_cacerts `
+           -replace 'scaffold_chef_client', $scaffold_chef_client
+    } | Set-Content "$pkg_prefix/hooks/run"
 }
 
 function Invoke-DefaultBuild {

--- a/scaffolding-chef-infra/tests/test.pester.ps1
+++ b/scaffolding-chef-infra/tests/test.pester.ps1
@@ -39,4 +39,15 @@ Describe "Chef client run doesn't fail" {
             $cert_pkg_dir | Should be "core/cacerts"
         }
     }
+
+    Context "API: scaffold_chef_client matches run hook stuartpreston/chef-client" {
+        It "The chef-client should be Stuart Preston's chef-client" {
+            $chef_client_pkg = Get-Content "C:\hab\svc\user-windows-default\hooks\run" | Select-String -Pattern '\w+/bin/chef-client.bat -z'
+            $chef_client_pkg = $chef_client_pkg -split ' '
+            $chef_client_pkg = $chef_client_pkg[2].split('\')
+            $chef_client_pkg = $chef_client_pkg[3] + '/' + $chef_client_pkg[4]
+
+            $chef_client_pkg | Should be "stuartpreston/chef-client"
+        }
+    }
 }

--- a/scaffolding-chef-infra/tests/test.ps1
+++ b/scaffolding-chef-infra/tests/test.ps1
@@ -28,7 +28,6 @@ Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start
 hab svc load $PackageIdentifier
 Start-Sleep $LOAD_WAIT_SECONDS
 
-
 $__dir=(Get-Item $PSScriptRoot)
 $test_result = Invoke-Pester -Strict -PassThru -Script @{
     Path = "$__dir/test.pester.ps1";


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This is a bug found while testing with the soon to be the official release of chef-client for windows. With chef 15 the license words need to be in quotes so that the flag works. Also Stuart's package is hard coded in the run which made it hard to not use Stuart's package.
