### PR TITLE
Fix typo in windows terraform config, closes #155

### DIFF
--- a/examples/terraform/aws-windows2016/windows2016.tf
+++ b/examples/terraform/aws-windows2016/windows2016.tf
@@ -93,9 +93,10 @@ set-executionpolicy -executionpolicy unrestricted -force -scope LocalMachine
       insecure = true
       https    = false
     }
+
     inline = [
       "hab pkg install core/windows-service",
-      "hab pkg exec core/window-service install",
+      "hab pkg exec core/windows-service install",
       "hab license accept",
     ]
   }


### PR DESCRIPTION
Per issue #155, there was a typo in calling the exec of the core/windows-service Habitat package as it was missing an 's'. This fixes that typo.

Signed-off-by: Evan Machnic <emachnic@gmail.com>

