### PR TITLE
Test latest ChefDK hab package version

### DIFF
--- a/examples/infra-linux-hardening/habitat/plan.sh
+++ b/examples/infra-linux-hardening/habitat/plan.sh
@@ -7,6 +7,7 @@ pkg_upstream_url="http://chef.io"
 pkg_scaffolding="chef/scaffolding-chef-infra"
 pkg_svc_user=("root")
 scaffold_policy_name="base"
+scaffold_chef_license="accept-no-persist"
 
 
 #######################################

--- a/examples/infra-linux-policyfile-cookbook/habitat/plan.sh
+++ b/examples/infra-linux-policyfile-cookbook/habitat/plan.sh
@@ -6,3 +6,4 @@ pkg_license=("Apache-2.0")
 pkg_scaffolding="chef/scaffolding-chef-infra"
 scaffold_policy_name="Policyfile"
 scaffold_policyfile_path="$PLAN_CONTEXT/../" # habitat/../Policyfile.rb
+scaffold_chef_license="accept-no-persist"

--- a/examples/inspec-linux-audit/habitat/plan.sh
+++ b/examples/inspec-linux-audit/habitat/plan.sh
@@ -5,3 +5,4 @@ pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=("Apache-2.0")
 pkg_description="Effortless Linux Audit Example"
 pkg_scaffolding="chef/scaffolding-chef-inspec"
+scaffold_chef_license="accept-no-persist"

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -22,7 +22,7 @@ scaffolding_load() {
 
   pkg_build_deps=(
     "${pkg_build_deps[@]}"
-    "${scaffold_chef_dk}"
+    "chef/chef-dk/4.4.14/20190905060033"
     "core/git"
   )
 

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -54,6 +54,19 @@ do_default_build_service() {
 }
 
 do_default_build() {
+  if [ -z "$scaffold_chef_license" ]; then
+    local error_msg="
+
+The Chef License must be accepted in your plan
+through the variable 'scaffold_chef_license=<value>'.
+
+More info: https://docs.chef.io/chef_license_accept.html
+
+"
+    exit_with "$error_msg" 7
+  fi
+  export CHEF_LICENSE="$scaffold_chef_license"
+
   if [ ! -d "${scaffold_policyfile_path}" ]; then
     build_line "A policyfile directory is required to build. More info: https://docs.chef.io/policyfile.html"
     exit 1

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -22,7 +22,7 @@ scaffolding_load() {
 
   pkg_build_deps=(
     "${pkg_build_deps[@]}"
-    "chef/chef-dk/4.4.14/20190905060033"
+    "${scaffold_chef_dk}"
     "core/git"
   )
 

--- a/scaffolding-chef-infra/tests/user-linux-default/habitat/plan.sh
+++ b/scaffolding-chef-infra/tests/user-linux-default/habitat/plan.sh
@@ -9,6 +9,7 @@ pkg_version="1.0.0"
 pkg_scaffolding="ci/scaffolding-chef-infra"
 pkg_svc_user=("root")
 scaffold_policy_name="ci"
+scaffold_chef_license="accept-no-persist"
 
 # Required Metadata for CI
 pkg_description="CI Test Plan for Linux"

--- a/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/cookbooks/ci/metadata.rb
+++ b/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/cookbooks/ci/metadata.rb
@@ -1,0 +1,2 @@
+name 'ci'
+version '1.0.0'

--- a/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/cookbooks/ci/recipes/default.rb
+++ b/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/cookbooks/ci/recipes/default.rb
@@ -1,0 +1,3 @@
+execute "echo-hello" do
+  command 'echo "Hello World"'
+end

--- a/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/habitat/default.toml
+++ b/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/habitat/plan.sh
+++ b/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/habitat/plan.sh
@@ -9,9 +9,15 @@ pkg_version="1.0.0"
 pkg_scaffolding="ci/scaffolding-chef-infra"
 pkg_svc_user=("root")
 scaffold_policy_name="ci"
-scaffold_chef_client="chef/chef-client/14.13.11"
-scaffold_cacerts="ci/cacerts"
-scaffold_chef_license="accept-no-persist"
+# When the user doesn't accept the license, then all builds will
+# fail with the error message:
+#
+# The Chef License must be accepted in your plan
+# through the variable 'scaffold_chef_license=<value>'.
+#
+# More info: https://docs.chef.io/chef_license_accept.html
+#
+#scaffold_chef_license="accept-no-persist"
 
 # Required Metadata for CI
 pkg_description="CI Test Plan for Linux"

--- a/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/policyfiles/ci.rb
+++ b/scaffolding-chef-infra/tests/user-linux-error-license-not-accepted/policyfiles/ci.rb
@@ -1,0 +1,7 @@
+name "ci"
+
+default_source :chef_repo, '../'
+
+run_list [
+  "ci::default",
+]

--- a/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/plan.sh
+++ b/scaffolding-chef-infra/tests/user-linux-include-policy/habitat/plan.sh
@@ -16,6 +16,7 @@ pkg_version="1.0.0"
 pkg_scaffolding="ci/scaffolding-chef-infra"
 pkg_svc_user=("root")
 scaffold_policy_name="$policy_name"
+scaffold_chef_license="accept-no-persist"
 
 # Required Metadata for CI
 pkg_description="CI Test Plan for include policy Linux"


### PR DESCRIPTION
## Test latest ChefDK hab package version
To be able to promote ChefDK hab package to stable we need a new
scaffolding variable to accept the chef license at build time.

### New `scaffold_chef_license` variable

If this variable is not set, the user will have the following error:
```
   user-linux: Building
   user-linux: ERROR:

The Chef License must be accepted in your plan
through the variable 'scaffold_chef_license=<value>'.

More info: https://docs.chef.io/chef_license_accept.html

   user-linux: Build time: 0m33s
   user-linux: Exiting on error
```