### PR TITLE
Fixes to Scaffolding for Chef 15

### DIFF
--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -13,14 +13,8 @@ cfg_splay={{cfg.splay}}
 cfg_splay="${cfg_splay:-1800}"
 cfg_splay_first_run={{cfg.splay_first_run}}
 cfg_splay_first_run="${cfg_splay_first_run:-0}"
-cfg_chef_license={{cfg.chef_license.acceptance}}
-cfg_chef_license="${cfg_chef_license:-undefined}"
 
-if [ "${cfg_chef_license}" == "undefined" ]; then
-  cfg_chef_license_cmd=""
-else
-  cfg_chef_license_cmd="--chef-license ${cfg_chef_license}"
-fi
+export CHEF_LICENSE="{{cfg.chef_license.acceptance}}"
 
 chef_client_cmd()
 {
@@ -29,7 +23,7 @@ chef_client_cmd()
   # causes the Chef Client to think that the policyfile is be overriden which is unsupported
   # and causes the chef run to fail.
   # shellcheck disable=SC2086
-  chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
+  chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}"
 }
 
 cfg_splay_duration=$(shuf -i 0-"${cfg_splay}" -n 1)

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -86,7 +86,7 @@ do_default_install() {
   shared_chunk=$(echo -e "${export_chunk}\n${shared_chunk}")
 
   bootstrap_chunk=$(cat "${lib_dir}"/bootstrap-chunk.rb)
-  echo -e "${shared_chunk}\n${bootstrap_chunk}" >> "${pkg_prefix}/config/bootstrap-config.rb"
+  echo -e "${export_chunk}\n${bootstrap_chunk}" >> "${pkg_prefix}/config/bootstrap-config.rb"
 
   client_chunk=$(cat "${lib_dir}"/client-chunk.rb)
   echo -e "${shared_chunk}\n${client_chunk}" >> "${pkg_prefix}/config/client-config.rb"

--- a/scaffolding-chef-infra/lib/windows/bootstrap-chunk.rb
+++ b/scaffolding-chef-infra/lib/windows/bootstrap-chunk.rb
@@ -1,1 +1,1 @@
-ENV['PATH'] += ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
+ENV['PATH'] += ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin;C:/Habitat/;C:/ProgramData/Habitat"

--- a/scaffolding-chef-infra/lib/windows/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/windows/client-chunk.rb
@@ -1,5 +1,5 @@
 cfg_env_path_prefix = '{{cfg.env_path_prefix}}'
-cfg_env_path_prefix ||= ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
+cfg_env_path_prefix ||= ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin;C:/Habitat/;C:/ProgramData/Habitat"
 ENV['PATH'] += cfg_env_path_prefix
 
 cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'

--- a/scaffolding-chef-infra/lib/windows/default.toml
+++ b/scaffolding-chef-infra/lib/windows/default.toml
@@ -6,7 +6,7 @@ splay = 1800
 splay_first_run = 0
 run_lock_timeout = 1800
 log_level = "warn"
-env_path_prefix = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
+env_path_prefix = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin;C:/Habitat/;C:/ProgramData/Habitat"
 ssl_verify_mode = ":verify_peer"
 
 [chef_license]

--- a/scaffolding-chef-infra/lib/windows/run.ps1
+++ b/scaffolding-chef-infra/lib/windows/run.ps1
@@ -26,19 +26,10 @@ if(!$env:CFG_SPLAY_FIRST_RUN){
     $env:CFG_SPLAY_FIRST_RUN = "0"
 }
 
-$env:CFG_CHEF_LICENSE = "{{cfg.chef_license.acceptance}}"
-if(!$env:CFG_CHEF_LICENSE){
-    $env:CFG_CHEF_LICENSE = "undefined"
-}
-
-if($env:CFG_CHEF_LICENSE -eq "undefined"){
-    $env:CFG_CHEF_LICENSE_CMD = ""
-} else {
-    $env:CFG_CHEF_LICENSE_CMD = "--chef-license '$env:CFG_CHEF_LICENSE'"
-}
+$env:CHEF_LICENSE = "{{cfg.chef_license.acceptance}}"
 
 function Invoke-ChefClient {
-  {{pkgPathFor "scaffold_chef_client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT $env:CFG_CHEF_LICENSE_CMD
+  {{pkgPathFor "scaffold_chef_client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT
 }
 
 $SPLAY_DURATION = Get-Random -InputObject (0..$env:CFG_SPLAY) -Count 1

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -107,7 +107,7 @@ function Invoke-DefaultInstall {
     $shared_chunk = "$export_chunk`n$shared_chunk"
 
     $bootstrap_chunk = (Get-Content -Path "$lib_dir/bootstrap-chunk.rb") -join "`n"
-    "$shared_chunk`n$bootstrap_chunk" | Add-Content -Path "$pkg_prefix/config/bootstrap-config.rb"
+    "$export_chunk`n$bootstrap_chunk" | Add-Content -Path "$pkg_prefix/config/bootstrap-config.rb"
 
     $client_chunk = (Get-Content -Path "$lib_dir/client-chunk.rb") -join "`n"
     "$shared_chunk`n$client_chunk" | Add-Content -Path "$pkg_prefix/config/client-config.rb"


### PR DESCRIPTION
* Use environment variables for chef_license acceptance because it is backwards compatible, and less error prone.  Plus if they are mis-set it will result in the standard MLSA workflow being kicked off.
* Bootstrap cannot rely on "shared chunk" as that has svc directory requirements.  changed it to include export and bootstrap.
* Fixed windows paths for non-chocolatey installs.

Signed-off-by: Nathan Cerny <ncerny@chef.io>

