### PR TITLE
ensure git is installed for the build-n-test script

### DIFF
--- a/bin/ci/build-and-run-tests.sh
+++ b/bin/ci/build-and-run-tests.sh
@@ -12,10 +12,22 @@ echo "--- :key: Generating fake origin key"
 hab origin key generate "${HAB_ORIGIN}"
 
 echo "--- :construction: Starting build for ${plan}"
-# We want to ensure that we build from the project root. This
-# creates a subshell so that the cd will only affect that process
+# We'll build from the root of the project's git repo. To do that,
+# we'll need to ensure git is installed to determine the
+# project root directory.
+if type git 2>/dev/null; then
+  echo "--- :thumbsup: git's installed"
+else
+  echo "--- :hammer_and_wrench: installing git"
+  hab pkg install core/git --binlink
+fi
 project_root="$(git rev-parse --show-toplevel)"
-(cd "$project_root" || exit 1
+
+# We want to ensure that we build the scaffolding package from the
+# project root. When changing directories in scripts, doing so in
+# a subshell () ensures that the script continues from the initial
+# runtime directory regardless of the actions within.
+( cd "$project_root" || exit 1
 
   echo "--- :construction: :linux: Building ${plan}"
   env DO_CHECK=true hab pkg build "${plan}"


### PR DESCRIPTION
In an effort to make the build-n-test script work immediately within a fresh studio, have the script confirm git is present or install it if not.

`type` is a shell built-in and will error if the command given is not present on the PATH. So build hosts that already have a git installed will continue to work, and studio clean rooms that do not will take care of themselves.

--

This is currently only for the Linux-flavored build'n'test. The PowerShell build'n'test currently also assumes git is around. Maybe to be fixed in this PR, maybe on another PR.