### PR TITLE
Add verify_api_cert support to scaffolding and set default value.

### DIFF
--- a/scaffolding-chef-infra/lib/linux/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/linux/client-chunk.rb
@@ -4,7 +4,11 @@ ENV['PATH'] = "#{cfg_env_path_prefix}:#{ENV['PATH']}"
 
 cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
 cfg_ssl_verify_mode ||= ':verify_peer'
-ssl_verify_mode "#{cfg_env_path_prefix}"
+ssl_verify_mode "#{cfg_ssl_verify_mode}"
+
+cfg_verify_api_cert = '{{cfg.verify_api_cert}}'
+cfg_verify_api_cert ||= false
+verify_api_cert "#{cfg_verify_api_cert}"
 
 {{#if cfg.automate.enable ~}}
 chef_guid '{{sys.member_id}}'

--- a/scaffolding-chef-infra/lib/linux/default.toml
+++ b/scaffolding-chef-infra/lib/linux/default.toml
@@ -8,6 +8,7 @@ run_lock_timeout = 1800
 log_level = "warn"
 env_path_prefix = "/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin"
 ssl_verify_mode = ":verify_peer"
+verify_api_cert = false
 
 [chef_license]
 acceptance = "undefined"

--- a/scaffolding-chef-infra/lib/windows/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/windows/client-chunk.rb
@@ -10,6 +10,10 @@ cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
 cfg_ssl_verify_mode ||= ":verify_peer"
 ssl_verify_mode "#{cfg_ssl_verify_mode}"
 
+cfg_verify_api_cert = '{{cfg.verify_api_cert}}'
+cfg_verify_api_cert ||= false
+verify_api_cert "#{cfg_verify_api_cert}"
+
 {{#if cfg.automate.enable ~}}
 chef_guid "{{sys.member_id}}"
 data_collector.token "{{cfg.automate.token}}"

--- a/scaffolding-chef-infra/lib/windows/default.toml
+++ b/scaffolding-chef-infra/lib/windows/default.toml
@@ -8,6 +8,7 @@ run_lock_timeout = 1800
 log_level = "warn"
 env_path_prefix = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
 ssl_verify_mode = ":verify_peer"
+verify_api_cert = false
 
 [chef_license]
 acceptance = "undefined"


### PR DESCRIPTION
When set to ```false```, the ```verify_api_cert``` config parameter will cause chef-client to use the ```ssl_verify_mode``` config parameter to control its SSL certificate verification.

In "standard mode" chef-client the ```verify_api_cert``` parameter defaults to ```false```, however when running in local mode chef-client will default this parameter to ```true```. This causes effortless packages to ignore ```ssl_verify_mode``` and consequently become unable to send data to an A2 server using a self-signed SSL certificate.

This pull request both adds the ```verify_api_cert``` parameter as a configurable for scaffolding-chef-infra and sets its default value to ```false```, meaning that packages built with this scaffolding will default to respecting ```ssl_verify_mode```.

This PR additionally fixes an issue where ```ssl_verify_mode``` was not set to the correct value on linux.

Signed-off-by: Jon Cowie <jonlives@gmail.com>