### PR TITLE
Fix typo in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -14,7 +14,7 @@ This issue tracker is for the code contained within this repo -- `chef/scaffoldi
 ## Description
 <!--- Briefly describe the issue -->
 
-## Chef Version
+## Scaffolding Version
 <!--- Tell us which version of scaffolding you are using. -->
 
 ## Platform Version


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

Quick fix to ensure that the version requested in the template is the Scaffolding not Chef.