### PR TITLE
change inspec scaffolding runhook to bash

### DIFF
--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -100,7 +100,7 @@ do_default_build_service() {
 
   # Run hook
   cat << EOF >> "$pkg_prefix/hooks/run"
-#!/bin/sh
+{{ pkgPathFor "core/bash" }}/bin/bash
 
 export HOME="{{pkg.svc_var_path}}"
 export INSPEC_CONFIG_DIR="{{pkg.svc_var_path}}"


### PR DESCRIPTION
Fixes a built package failing with `run: Syntax error: "(" unexpected` due to sh/bash differences

Signed-off-by: Josh Brand <jbrand@chef.io>

