### PR TITLE
Remove erroneous override of data bag path on windows

### DIFF
--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -109,7 +109,6 @@ function Invoke-DefaultInstall {
 
     (Get-Content -Path "$lib_dir/default.toml") -join "`n" | Add-Content -Path "$pkg_prefix/default.toml"
 
-    $scaffold_data_bags_path = "not_using_data_bags"
     if (Test-Path "$scaffold_data_bags_path") {
         Copy-Item "$scaffold_data_bags_path/*" -Destination "$pkg_prefix" -Recurse
     }


### PR DESCRIPTION
It looks like this line was left in during testing, and it breaks usage of databags on windows.
Signed-off-by: Jon Cowie <jonlives@gmail.com>

