### PR TITLE
Remove pkg_dep in scaffold plan

### DIFF
--- a/scaffolding-chef-inspec/plan.ps1
+++ b/scaffolding-chef-inspec/plan.ps1
@@ -5,7 +5,6 @@ $pkg_version="$(Get-Content $PLAN_CONTEXT\..\VERSION)"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=("Apache-2.0")
 $pkg_upstream_url="https://www.chef.sh"
-$pkg_deps=@("chef/inspec")
 
 function Invoke-Install {
     New-Item -ItemType Directory -Path "$pkg_prefix/lib"


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

There is an issue that if the version of scaffolding is built with a version of InSpec that is greater than the  one specified in the build that will be used instead of the one specified in the build.