### PR TITLE
Make windows use official chef-client

### DIFF
--- a/scaffolding-chef-infra/lib/windows/run.ps1
+++ b/scaffolding-chef-infra/lib/windows/run.ps1
@@ -31,14 +31,10 @@ if(!$env:CFG_CHEF_LICENSE){
     $env:CFG_CHEF_LICENSE = "undefined"
 }
 
-if($env:CFG_CHEF_LICENSE -eq "undefined"){
-    $env:CFG_CHEF_LICENSE_CMD = ""
-} else {
-    $env:CFG_CHEF_LICENSE_CMD = "--chef-license '$env:CFG_CHEF_LICENSE'"
-}
+$env:CHEF_LICENSE = $env:CFG_CHEF_LICENSE
 
 function Invoke-ChefClient {
-  {{pkgPathFor "scaffold_chef_client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT $env:CFG_CHEF_LICENSE_CMD
+  {{pkgPathFor "scaffold_chef_client"}}/bin/chef-client.bat -z -l $env:CFG_LOG_LEVEL -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout $env:CFG_RUN_LOCK_TIMEOUT
 }
 
 $SPLAY_DURATION = Get-Random -InputObject (0..$env:CFG_SPLAY) -Count 1

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -2,10 +2,7 @@
 # A scaffolding for Chef Policyfile packages
 #
 if(!$scaffold_chef_client){
-    $scaffold_chef_client = "stuartpreston/chef-client"
-}
-if(!$scaffold_chef_dk) {
-    $scaffold_chef_dk = "core/chef-dk"
+    $scaffold_chef_client = "chef/chef-infra-client"
 }
 if(!$scaffold_cacerts){
     $scaffold_cacerts = "core/cacerts"
@@ -42,7 +39,6 @@ function Load-Scaffolding {
     )
 
     $pkg_build_deps += @(
-        "$scaffold_chef_dk",
         "core/git"
     )
 
@@ -63,6 +59,7 @@ function Invoke-DefaultBuildService {
 }
 
 function Invoke-DefaultBuild {
+    $env:CHEF_LICENSE = 'accept-no-persist'
     Remove-Item "$scaffold_policyfile_path/*.lock.json" -Force
     $policyfile = "$scaffold_policyfile_path/$scaffold_policy_name.rb"
 
@@ -81,13 +78,13 @@ function Invoke-DefaultBuild {
             exit 1
         }
         Write-BuildLine "Detected included policyfile, $p.rb, installing"
-        chef install "$scaffold_policyfile_path/$p.rb"
+        chef-cli install "$scaffold_policyfile_path/$p.rb"
     }
-    chef install "$policyfile"
+    chef-cli install "$policyfile"
 }
 
 function Invoke-DefaultInstall {
-    chef export "$scaffold_policyfile_path/$scaffold_policy_name.lock.json" "$pkg_prefix"
+    chef-cli export "$scaffold_policyfile_path/$scaffold_policy_name.lock.json" "$pkg_prefix"
 
     $dir = "$pkg_prefix/config"
     if (!(Test-Path -Path $dir)) {

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -58,11 +58,14 @@ function Invoke-DefaultBuildService {
     } | Set-Content "$pkg_prefix/hooks/run"
 }
 
+Invoke-SetupEnvironment {
+    Push-BuildtimeEnv -IsPath GEM_PATH "$(Get-HabPackagePath $scaffolding_package)/vendor"
+}
+
 function Invoke-DefaultBuild {
     $env:CHEF_LICENSE = 'accept-no-persist'
     Remove-Item "$scaffold_policyfile_path/*.lock.json" -Force
     $policyfile = "$scaffold_policyfile_path/$scaffold_policy_name.rb"
-    $env:PATH += ";$(Get-HabPackagePath $scaffolding_package)/vendor/bin"
 
     Get-Content $policyfile | ? { $_.StartsWith("include_policy") } | % {
         $p = $_.Split()[1]

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -62,7 +62,7 @@ function Invoke-DefaultBuild {
     $env:CHEF_LICENSE = 'accept-no-persist'
     Remove-Item "$scaffold_policyfile_path/*.lock.json" -Force
     $policyfile = "$scaffold_policyfile_path/$scaffold_policy_name.rb"
-    $env:PATH += ";$(pkg_path_for "${pkg_scaffolding}")/vendor/bin"
+    $env:PATH += ";$(Get-HabPackagePath $scaffolding_package)/vendor/bin"
 
     Get-Content $policyfile | ? { $_.StartsWith("include_policy") } | % {
         $p = $_.Split()[1]

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -39,7 +39,7 @@ function Load-Scaffolding {
     )
 
     $pkg_build_deps += @(
-        "$scaffold_package",
+        "$scaffolding_package",
         "core/git"
     )
 

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -39,7 +39,7 @@ function Load-Scaffolding {
     )
 
     $pkg_build_deps += @(
-        "$scaffolding_package",
+        "$pkg_scaffolding",
         "core/git"
     )
 

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -62,6 +62,7 @@ function Invoke-DefaultBuild {
     $env:CHEF_LICENSE = 'accept-no-persist'
     Remove-Item "$scaffold_policyfile_path/*.lock.json" -Force
     $policyfile = "$scaffold_policyfile_path/$scaffold_policy_name.rb"
+    $env:PATH += ";$(pkg_path_for "${pkg_scaffolding}")/vendor/bin"
 
     Get-Content $policyfile | ? { $_.StartsWith("include_policy") } | % {
         $p = $_.Split()[1]
@@ -78,6 +79,7 @@ function Invoke-DefaultBuild {
             exit 1
         }
         Write-BuildLine "Detected included policyfile, $p.rb, installing"
+
         chef-cli install "$scaffold_policyfile_path/$p.rb"
     }
     chef-cli install "$policyfile"

--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -39,6 +39,7 @@ function Load-Scaffolding {
     )
 
     $pkg_build_deps += @(
+        "$scaffold_package",
         "core/git"
     )
 
@@ -56,10 +57,6 @@ function Invoke-DefaultBuildService {
         $_ -replace 'scaffold_cacerts', $scaffold_cacerts `
            -replace 'scaffold_chef_client', $scaffold_chef_client
     } | Set-Content "$pkg_prefix/hooks/run"
-}
-
-Invoke-SetupEnvironment {
-    Push-BuildtimeEnv -IsPath GEM_PATH "$(Get-HabPackagePath $scaffolding_package)/vendor"
 }
 
 function Invoke-DefaultBuild {

--- a/scaffolding-chef-infra/plan.ps1
+++ b/scaffolding-chef-infra/plan.ps1
@@ -13,6 +13,7 @@ $pkg_bin_dirs=@("vendor/bin")
 
 function Invoke-Setupenvironment {
   Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
+  Push-BuildtimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
 }
 
 function Invoke-Build {

--- a/scaffolding-chef-infra/plan.ps1
+++ b/scaffolding-chef-infra/plan.ps1
@@ -6,11 +6,22 @@ $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=("Apache-2.0")
 $pkg_upstream_url="https://www.chef.sh"
 $pkg_deps=@(
-    "core/chef-dk"
-    "core/git"
+    "core/git",
+    "chef/ruby-plus-devkit"
 )
+$pkg_bin_dirs=@("vendor/bin")
+
+function Invoke-Setupenvironment {
+  Push-RuntimeEnv -IsPath GEM_PATH "$pkg_prefix/vendor"
+}
+
+function Invoke-Build {
+  $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
+  gem install chef-cli --no-document
+}
 
 function Invoke-Install {
   New-Item -ItemType directory -Path "$pkg_prefix/lib/windows"
+  Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/*" -Destination $pkg_prefix -Recurse -Exclude @("gem_make.out", "mkmf.log", "Makefile") -Force
   Copy-Item -Path "$PLAN_CONTEXT/lib/windows/*" -Destination "$pkg_prefix/lib" -Recurse
 }

--- a/scaffolding-chef-infra/tests/user-windows-api/habitat/default.toml
+++ b/scaffolding-chef-infra/tests/user-windows-api/habitat/default.toml
@@ -2,4 +2,4 @@
 # Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
 
 [chef_license]
-acceptance = "undefined"
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-infra/tests/user-windows-default/habitat/default.toml
+++ b/scaffolding-chef-infra/tests/user-windows-default/habitat/default.toml
@@ -2,4 +2,4 @@
 # Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
 
 [chef_license]
-acceptance = "undefined"
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-infra/tests/user-windows-default/tests/test.pester.ps1
+++ b/scaffolding-chef-infra/tests/user-windows-default/tests/test.pester.ps1
@@ -49,13 +49,13 @@ Describe "Chef client run doesn't fail" {
     }
 
     Context "API: scaffold_chef_client matches run hook stuartpreston/chef-client" {
-        It "The chef-client should be Stuart Preston's chef-client" {
+        It "The chef-client should be the official chef-infra-client" {
             $chef_client_pkg = Get-Content "C:\hab\svc\user-windows-default\hooks\run" | Select-String -Pattern '\w+/bin/chef-client.bat -z'
             $chef_client_pkg = $chef_client_pkg -split ' '
             $chef_client_pkg = $chef_client_pkg[2].split('\')
             $chef_client_pkg = $chef_client_pkg[3] + '/' + $chef_client_pkg[4]
 
-            $chef_client_pkg | Should be "stuartpreston/chef-client"
+            $chef_client_pkg | Should be "chef/chef-infra-client"
         }
     }
 }

--- a/scaffolding-chef-infra/tests/user-windows-default/tests/test.ps1
+++ b/scaffolding-chef-infra/tests/user-windows-default/tests/test.ps1
@@ -23,7 +23,7 @@ Start-Sleep $SUP_WAIT_SECONDS
 
 $LOAD_WAIT_SECONDS = 60
 
-Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start..."
+Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start...."
 hab svc load $PackageIdentifier
 Start-Sleep $LOAD_WAIT_SECONDS
 


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This is the change to the official chef-infra-clients for windows. In order for this to happen I needed to vendor the chef-cli gem into the scaffolding so that it can be shipped with scaffolding.
