### PR TITLE
Fix data_bag handling in windows scaffolding

### DIFF
--- a/scaffolding-chef-infra/lib/windows/scaffolding.ps1
+++ b/scaffolding-chef-infra/lib/windows/scaffolding.ps1
@@ -110,7 +110,7 @@ function Invoke-DefaultInstall {
     (Get-Content -Path "$lib_dir/default.toml") -join "`n" | Add-Content -Path "$pkg_prefix/default.toml"
 
     if (Test-Path "$scaffold_data_bags_path") {
-        Copy-Item "$scaffold_data_bags_path/*" -Destination "$pkg_prefix" -Recurse
+        Copy-Item "$scaffold_data_bags_path" -Destination "$pkg_prefix" -Recurse
     }
 
     Remove-Item "$pkg_prefix/.chef" -Force -Recurse


### PR DESCRIPTION
The windows scaffolding currently contains a bug which causes the *contents* of the data_bags directory to be copied into the package, but not the top level directory itself. This pull request fixes this functionality and brings it in line with the behaviour of the Linux scaffolding.

Signed-off-by: Jon Cowie <jonlives@gmail.com>

