### PR TITLE
Hard code the client paths

### DIFF
--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -29,7 +29,7 @@ chef_client_cmd()
   # causes the Chef Client to think that the policyfile is be overriden which is unsupported
   # and causes the chef run to fail.
   # shellcheck disable=SC2086
-  chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
+  {{pkgPathFor "${scaffold_chef_client}"}}/bin/chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
 }
 
 cfg_splay_duration=$(shuf -i 0-"${cfg_splay}" -n 1)

--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -28,7 +28,7 @@ chef_client_cmd()
   # This only applies to the cfg_chef_license_cmd because putting quotes around the variable
   # causes the Chef Client to think that the policyfile is be overriden which is unsupported
   # and causes the chef run to fail.
-  # shellcheck disable=SC2086
+  # shellcheck disable=SC2086,SC1073,SC1054,SC1054
   {{pkgPathFor "${scaffold_chef_client}"}}/bin/chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
 }
 
@@ -47,3 +47,4 @@ while true; do
   sleep "${cfg_interval}"
   chef_client_cmd
 done
+# shellcheck disable=SC1072,SC1056

--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -47,4 +47,3 @@ while true; do
   sleep "${cfg_interval}"
   chef_client_cmd
 done
-# shellcheck disable=SC1072,SC1056

--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -28,8 +28,8 @@ chef_client_cmd()
   # This only applies to the cfg_chef_license_cmd because putting quotes around the variable
   # causes the Chef Client to think that the policyfile is be overriden which is unsupported
   # and causes the chef run to fail.
-  # shellcheck disable=SC2086,SC1073,SC1054,SC1054
-  {{pkgPathFor "${scaffold_chef_client}"}}/bin/chef-client -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
+  # shellcheck disable=SC1009,SC2086,SC1073,SC1054,SC1054
+  "{{pkgPathFor "${scaffold_chef_client}"}}/bin/chef-client" -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
 }
 
 cfg_splay_duration=$(shuf -i 0-"${cfg_splay}" -n 1)

--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -28,7 +28,7 @@ chef_client_cmd()
   # This only applies to the cfg_chef_license_cmd because putting quotes around the variable
   # causes the Chef Client to think that the policyfile is be overriden which is unsupported
   # and causes the chef run to fail.
-  # shellcheck disable=SC1009,SC2086,SC1073,SC1054,SC1054
+  # shellcheck disable=SC2086
   "{{pkgPathFor "${scaffold_chef_client}"}}/bin/chef-client" -z -l "${cfg_log_level}" -c {{pkg.svc_config_path}}/client-config.rb -j {{pkg.svc_config_path}}/attributes.json --once --no-fork --run-lock-timeout "${cfg_run_lock_timeout}" $cfg_chef_license_cmd
 }
 

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -49,7 +49,7 @@ do_default_build_service() {
   mkdir -p "${pkg_prefix}/hooks"
   # Template buildtime variables into the run hook.
   # This allows us to render the run hook from a file.
-  sed -e "s,\${scaffold_cacerts},${scaffold_cacerts},g" "${lib_dir}/run.bash" >> "${pkg_prefix}/hooks/run"
+  sed -e "s,\${scaffold_cacerts},${scaffold_cacerts},g;s,\${scaffold_chef_client},${scaffold_chef_client},g" "${lib_dir}/run.bash" >> "${pkg_prefix}/hooks/run"
   chmod 0750 -R "${pkg_prefix}/hooks"
 }
 

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -136,7 +136,7 @@ echo \${cfg_waiver_cmd}
 
 inspec_cmd()
 {
-  inspec exec \${PROFILE_PATH} --config \${CONFIG} \${cfg_waiver_cmd} --chef-license \$CFG_CHEF_LICENSE --log-level \$CFG_LOG_LEVEL
+  {{pkgPathFor "${scaffold_inspec_client}"}}/bin/inspec exec \${PROFILE_PATH} --config \${CONFIG} \${cfg_waiver_cmd} --chef-license \$CFG_CHEF_LICENSE --log-level \$CFG_LOG_LEVEL
 }
 
 


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This change hard codes the paths of the clients to garuntee the version of the client that is used is the one that the package is packaged with.

#200 