### PR TITLE
Fix plan so it's not templates

### DIFF
--- a/examples/effortless_config/chef_repo_pattern/habitat/plan.ps1
+++ b/examples/effortless_config/chef_repo_pattern/habitat/plan.ps1
@@ -1,11 +1,3 @@
-
-if ($env:CHEF_POLICYFILE -eq $null){
-  $policy_name = "base"
-}
-else{
-  $policy_name = $env:CHEF_POLICYFILE
-}
-
 $pkg_name="effortless-config-baseline"
 $pkg_origin="chef"
 $pkg_version="0.1.0"

--- a/examples/effortless_config/chef_repo_pattern/habitat/plan.sh
+++ b/examples/effortless_config/chef_repo_pattern/habitat/plan.sh
@@ -1,11 +1,4 @@
-#@IgnoreInspection BashAddShebang
-if [ -z ${CHEF_POLICYFILE+x} ]; then
-  policy_name="base"
-else
-  policy_name=${CHEF_POLICYFILE}
-fi
-
-pkg_name=effortless-config-${policy_name}line
+pkg_name=effortless-config-baseline
 pkg_origin=effortless
 pkg_version="0.1.0"
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This pulls out the templating of the build so that it just uses that base package name so expeditor can build it.