### PR TITLE
Add support for --insecure flag on compliance login for profile retrieval

### DIFF
--- a/examples/effortless_audit/windows/Readme.md
+++ b/examples/effortless_audit/windows/Readme.md
@@ -1,0 +1,46 @@
+# Effortless Audit
+
+Effortless Audit is a way to package up your InSpec profiles into a Habitat Application allowing you to easily update them promote them through channels using Habitat Builder and be deterministic about the version of Inspec you are using with your profiles.
+
+## Introduction 
+
+Welcome to the Effortless Audit Pattern! This set of examples provides an opinionated structure and usage methodology alongside documentation on the motivations for this pattern and it's typical usage.
+
+## Directory Stucture
+
+This example demonstrates how to use the scaffolding to build a wrapper profile for a profile that is stored in Chef Automate. Since the profiles in automate are OS or platform specific this example is broken into two folders one for `Windows` and one for `Linux`. They are very similar and only differ in the source profiles they are wrapping.
+
+## Requirements
+To configure and build a Effortless Audit application, you will need Habitat installed and configured on your development workstation. If you want to upload the package to Habitat Builder, you'll also need to have configured an origin and downloaded its keys into your local Habitat key cache.
+
+You can find instructions on how to work with Habitat Builder [here](https://www.habitat.sh/docs/using-builder/)
+
+## Build
+
+To build the app you just need to copy the habitat folder into your profile folder.
+> Note: You can also just run the next steps out of the linux or windows folder
+
+Once you have completed the above steps, the process for building this application is the same as any other Habitat application:
+
+> (please note lines beginning ```[1][default:/src:0]#``` indicate commands run inside hab studio - this portion of the line should not be typed. For Windows builds, you should cd into the `habitat-win/` directory before running the build command)
+
+```
+$> hab studio enter
+[1][default:/src:0]# build
+```
+
+Once the build process has successfully completed, you should see lines similar to the following at the end of the build output:
+
+```
+   compliance: Source Path: /src
+   compliance: Installed Path: /hab/pkgs/jonlives/compliance/0.1.0/20190116131348
+   compliance: Artifact: /src/results/jonlives-compliance-0.1.0-20190116131348-x86_64-linux.hart
+   compliance: Build Report: /src/results/last_build.env
+   compliance: SHA256 Checksum: a5abe6dde45baf4db5e4441d3bd6defa2f77fd372c634aa366c431ce854c86b4
+   compliance: Blake2b Checksum: e1074c38b79ac3d61f46d7db595ef0bf0567b6d6e8818c1f86d6c0c153496a52
+   compliance:
+   compliance: I love it when a plan.sh comes together.
+   compliance:
+   compliance: Build time: 0m21s
+```
+The artifact line shows you the path to your newly-build Effortless Audit artifact which can now be uploaded to Habitat Builder or exported to a Docker container to run locally.

--- a/examples/effortless_audit/windows/habitat/plan.ps1
+++ b/examples/effortless_audit/windows/habitat/plan.ps1
@@ -8,4 +8,4 @@ $pkg_scaffolding="chef/scaffolding-chef-inspec"
 $scaffold_automate_server_url = "$env:AUTOMATE_SERVER_URL" # Example: https://foo.bar.com
 $scaffold_automate_user = "$env:AUTOMATE_USER"             # Example: "admin"
 $scaffold_automate_token = "$env:AUTOMATE_TOKEN"           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
-#$scaffold_compliance_insecure = true                      # set true to ignore SSL cert error when retrieving profile from A2
+#$scaffold_compliance_insecure = $TRUE                      # set true to ignore SSL cert error when retrieving profile from A2

--- a/examples/effortless_audit/windows/linux/controls/example.rb
+++ b/examples/effortless_audit/windows/linux/controls/example.rb
@@ -1,0 +1,5 @@
+title 'CIS Automate Test'
+
+include_controls 'cis-rhel7-level1-server' do
+  skip_control 'xccdf_org.cisecurity.benchmarks_rule_1.1.14_Ensure_nodev_option_set_on_home_partition'
+end

--- a/examples/effortless_audit/windows/linux/habitat/plan.sh
+++ b/examples/effortless_audit/windows/linux/habitat/plan.sh
@@ -1,0 +1,8 @@
+pkg_name=effortless-a2-profile-test
+pkg_version=1.0.0
+pkg_origin=chef
+pkg_scaffolding="chef/scaffolding-chef-inspec"
+scaffold_automate_server_url=$AUTOMATE_SERVER_URL # Example: https://foo.bar.com
+scaffold_automate_user=$AUTOMATE_USER             # Example: "admin"
+scaffold_automate_token=$AUTOMATE_TOKEN           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
+#scaffold_compliance_insecure=true                # set true to ignore SSL cert error when retrieving profile from A2

--- a/examples/effortless_audit/windows/linux/inspec.yml
+++ b/examples/effortless_audit/windows/linux/inspec.yml
@@ -1,0 +1,7 @@
+name: effortless-a2-profile-test
+title: Effortless Automate CIS profile Test
+version: 1.0.0
+
+depends:
+  - name: cis-rhel7-level1-server
+    compliance: admin/cis-rhel7-level1-server

--- a/examples/effortless_config/chef_repo_pattern/habitat/default.toml.example
+++ b/examples/effortless_config/chef_repo_pattern/habitat/default.toml.example
@@ -59,3 +59,4 @@ token = "<automate_token>"
 
 [chef_license]
 acceptance = "undefined"
+

--- a/scaffolding-chef-inspec/lib/scaffolding.ps1
+++ b/scaffolding-chef-inspec/lib/scaffolding.ps1
@@ -46,9 +46,17 @@ function Invoke-DefaultBefore {
             exit 1
         }
         else{
-            inspec compliance login "$scaffold_automate_server_url" `
-                            --user "$scaffold_automate_user" `
-                            --token "$scaffold_automate_token"
+            if(!$scaffold_compliance_insecure){
+                inspec compliance login "$scaffold_automate_server_url" `
+                                --user "$scaffold_automate_user" `
+                                --token "$scaffold_automate_token"
+            }
+            else{
+                inspec compliance login "$scaffold_automate_server_url" `
+                                --user "$scaffold_automate_user" `
+                                --token "$scaffold_automate_token" `
+                                --insecure
+            }
         }
     }
 }

--- a/scaffolding-chef-inspec/lib/scaffolding.ps1
+++ b/scaffolding-chef-inspec/lib/scaffolding.ps1
@@ -105,8 +105,10 @@ if(!`$env:CFG_CHEF_LICENSE){
 }
 `$env:CHEF_LICENSE = `$env:CFG_CHEF_LICENSE
 `$WAIVER="{{pkg.svc_config_path}}/waiver.yml"
+`$INPUTS="{{pkg.svc_config_path}}/inputs.yml"
 `$CONFIG="{{pkg.svc_config_path}}/inspec_exec_config.json"
 `$PROFILE_PATH="{{pkg.path}}/{{pkg.name}}-{{pkg.version}}.tar.gz"
+
 
 # Get the InSpec Version
 `$inspec_version = ({{pkgPathFor "$scaffold_inspec_client"}}/bin/inspec.bat --version)
@@ -124,7 +126,7 @@ function Invoke-Inspec {
     # TODO: This is set to --json-config due to the
     #  version of InSpec being used please update when InSpec is updated
     if(`$version -gt [Version]"4.17.27"){
-        {{pkgPathFor "$scaffold_inspec_client"}}/bin/inspec.bat exec `$PROFILE_PATH --config `$CONFIG --waiver-file `$WAIVER --log-level `$env:CFG_LOG_LEVEL
+        {{pkgPathFor "$scaffold_inspec_client"}}/bin/inspec.bat exec `$PROFILE_PATH --config `$CONFIG --waiver-file `$WAIVER --input-file `$INPUTS--log-level `$env:CFG_LOG_LEVEL
     } 
     else {
         {{pkgPathFor "$scaffold_inspec_client"}}/bin/inspec.bat exec `$PROFILE_PATH --json-config `$CONFIG --log-level `$env:CFG_LOG_LEVEL
@@ -211,6 +213,11 @@ user = '<automate_user>'
     Add-Content -Path "$pkg_prefix/config/waiver.yml" -Value @"
 {{#if cfg.waivers ~}}
 {{toYaml cfg.waivers}}
+{{/if ~}}
+"@
+Add-Content -Path "$pkg_prefix/config/inputs.yml" -Value @"
+{{#if cfg.inputs ~}}
+{{toYaml cfg.inputs}}
 {{/if ~}}
 "@
 }

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -70,6 +70,7 @@ do_default_before() {
                               --user $scaffold_automate_user \
                               --token $scaffold_automate_token \
                               --insecure
+      fi
     fi
   fi
 }

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -127,6 +127,7 @@ CFG_CHEF_LICENSE={{cfg.chef_license.acceptance}}
 CFG_CHEF_LICENSE="\${CFG_CHEF_LICENSE:-undefined}"
 CONFIG="{{pkg.svc_config_path}}/inspec_exec_config.json"
 WAIVER="{{pkg.svc_config_path}}/waiver.yml"
+INPUTS="{{pkg.svc_config_path}}/inputs.yml"
 PROFILE_PATH="{{pkg.path}}/{{pkg.name}}-{{pkg.version}}.tar.gz"
 
 # This function compares the versions of inspec to ensure that
@@ -144,7 +145,7 @@ echo \${cfg_waiver_cmd}
 
 inspec_cmd()
 {
-  {{pkgPathFor "${scaffold_inspec_client}"}}/bin/inspec exec \${PROFILE_PATH} --config \${CONFIG} \${cfg_waiver_cmd} --chef-license \$CFG_CHEF_LICENSE --log-level \$CFG_LOG_LEVEL
+  {{pkgPathFor "${scaffold_inspec_client}"}}/bin/inspec exec \${PROFILE_PATH} --config \${CONFIG} \${cfg_waiver_cmd} --input-file \${INPUTS} --chef-license \$CFG_CHEF_LICENSE --log-level \$CFG_LOG_LEVEL
 }
 
 
@@ -233,6 +234,16 @@ EOF
 {{/if ~}}
 EOF
   chmod 0640 "$pkg_prefix/config/waiver.yml"
+
+  cat << EOF >> "$pkg_prefix/config/inputs.yml"
+{{#if cfg.inputs ~}}
+{{toYaml cfg.inputs}}
+{{else ~}}
+{}
+{{/if ~}}
+EOF
+  chmod 0640 "$pkg_prefix/config/inputs.yml"
+
 }
 
 do_default_strip() {

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -60,9 +60,16 @@ do_default_before() {
       build_line "$message"
       exit 1
     else
-      inspec compliance login $scaffold_automate_server_url \
+      if [ ! $scaffold_compliance_insecure ]; then
+        inspec compliance login $scaffold_automate_server_url\
+                                --user $scaffold_automate_user \
+                                --token $scaffold_automate_token \
+
+      else
+        inspec compliance login $scaffold_automate_server_url \
                               --user $scaffold_automate_user \
-                              --token $scaffold_automate_token
+                              --token $scaffold_automate_token \
+                              --insecure
     fi
   fi
 }

--- a/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/controls/example.rb
+++ b/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/controls/example.rb
@@ -1,0 +1,5 @@
+title 'CIS Automate Test'
+
+include_controls 'cis-rhel7-level1-server' do
+  skip_control 'xccdf_org.cisecurity.benchmarks_rule_1.1.14_Ensure_nodev_option_set_on_home_partition'
+end

--- a/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/habitat/plan.sh
@@ -5,4 +5,4 @@ pkg_scaffolding="chef/scaffolding-chef-inspec"
 scaffold_automate_server_url=$AUTOMATE_SERVER_URL # Example: https://foo.bar.com
 scaffold_automate_user=$AUTOMATE_USER             # Example: "admin"
 scaffold_automate_token=$AUTOMATE_TOKEN           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
-#scaffold_compliance_insecure=true                # set true to ignore SSL cert error when retrieving profile from A2
+scaffold_compliance_insecure=true

--- a/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/inspec.yml
+++ b/scaffolding-chef-inspec/tests/linux/user-a2insecure-profile-dep/inspec.yml
@@ -1,0 +1,7 @@
+name: effortless-a2-profile-test
+title: Effortless Automate CIS profile Test
+version: 1.0.0
+
+depends:
+  - name: cis-rhel7-level1-server
+    compliance: admin/cis-rhel7-level1-server

--- a/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/controls/example.rb
+++ b/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/controls/example.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+title 'STIG testing'
+
+include_controls 'stig-windowsserver2016-i-missioncriticalpublic' do
+  skip_control 'xccdf_mil.disa.stig_rule_SV-87949r1_rule'
+end

--- a/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/habitat/plan.ps1
@@ -10,4 +10,4 @@ $pkg_scaffolding="chef/scaffolding-chef-inspec"
 $scaffold_automate_server_url = "$env:AUTOMATE_SERVER_URL" # Example: https://foo.bar.com
 $scaffold_automate_user = "$env:AUTOMATE_USER"             # Example: "admin"
 $scaffold_automate_token = "$env:AUTOMATE_TOKEN"           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
-$scaffold_compliance_insecure=true
+$scaffold_compliance_insecure = $TRUE

--- a/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/habitat/plan.ps1
@@ -3,9 +3,11 @@ $pkg_origin="chef"
 $pkg_version="0.1.0"
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license=("Apache-2.0")
+$pkg_build_deps=@("stuartpreston/inspec")
+$pkg_deps=@("stuartpreston/inspec")
 $pkg_description="Effortless Windows Audit"
 $pkg_scaffolding="chef/scaffolding-chef-inspec"
 $scaffold_automate_server_url = "$env:AUTOMATE_SERVER_URL" # Example: https://foo.bar.com
 $scaffold_automate_user = "$env:AUTOMATE_USER"             # Example: "admin"
 $scaffold_automate_token = "$env:AUTOMATE_TOKEN"           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
-#$scaffold_compliance_insecure = true                      # set true to ignore SSL cert error when retrieving profile from A2
+$scaffold_compliance_insecure=true

--- a/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/inspec.yml
+++ b/scaffolding-chef-inspec/tests/windows/user-a2insecure-profile-dep/inspec.yml
@@ -1,0 +1,12 @@
+name: stig-testing-audit
+title: Effortless stig testing Audit
+maintainer: humans@habitat.sh
+copyright: Chef Software Inc.
+copyright_email: humans@habitat.sh
+license: Apache-2.0
+summary: Effortless Audit Windows Baseline
+version: 0.1.0
+
+depends:
+  - name: stig-windowsserver2016-i-missioncriticalpublic
+    compliance: admin/stig-windowsserver2016-i-missioncriticalpublic


### PR DESCRIPTION
If an Automate server is using self signed SSL cert, inspec compliance login fails with SSL error during build effortless audit package. Does not seem to support standard SSL cert file override locations during build time.

This change adds an optional "scaffold_compliance_insecure" environment variable that, when set to non-false value, will add the "--insecure" option to the inspec compliance login command during build phase.

The primary change is in scaffold.ps1 and scaffold.sh for Inspec. Also added examples and tests with the scaffold_compliance_insecure variable.