### PR TITLE
[DO NOT MERGE] Bump ruby to match Chef client

### DIFF
--- a/scaffolding-chef-infra/plan.ps1
+++ b/scaffolding-chef-infra/plan.ps1
@@ -7,7 +7,7 @@ $pkg_license=("Apache-2.0")
 $pkg_upstream_url="https://www.chef.sh"
 $pkg_deps=@(
     "core/git",
-    "chef/ruby-plus-devkit"
+    "chef/ruby27-plus-devkit"
 )
 $pkg_bin_dirs=@("vendor/bin")
 


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

The Ruby that is used for the chef-cli needs to be the same as the chef-client so that we don't get gem errors during build.