### PR TITLE
Remove the chefdk dependency

### DIFF
--- a/components/effortless-chef-io/variables-and-config.md
+++ b/components/effortless-chef-io/variables-and-config.md
@@ -10,10 +10,6 @@ You can use all the default plan variables that are shipped with habitat you can
 
 **$scaffold_chef_client**: Variable to change the chef-client habitat package that is used. Default is `chef/chef-infra-client`
 
-**$scaffold_chef_dk**: Varible to change the chef-dk habitat package that is used. Default is `chef/chef-dk` (Linux Only)
-
-  > Note: The windows scaffolding no longer uses the chef-dk as of version 0.18.0 instead it ships with a vendored version of the `chef-cli` command.
-
 **$scaffold_cacerts**: Variable to change the CACerts habitat package that is used during the chef-client run. Default is `chef/cacerts`
 
 **$scaffold_policyfile_path**: Path to the policyfile to be built. Default is `$PLAN_CONTEXT/../policyfiles`

--- a/examples/effortless_config/chef_repo_pattern/habitat/plan.sh
+++ b/examples/effortless_config/chef_repo_pattern/habitat/plan.sh
@@ -24,9 +24,6 @@ scaffold_policy_name="base"
 # scaffold_chef_client="chef/chef-client"
 # allows you to hard-pin to a version of the chef-infra-client
 
-# scaffold_chef_dk="chef/chef-dk"
-# allows you to hard-pin to a version of chef-dk
-
 # scaffold_data_bags_path="$PLAN_CONTEXT/../data_bags"
 # allows you to build data bags into the package
 

--- a/scaffolding-chef-infra/lib/linux/scaffolding.sh
+++ b/scaffolding-chef-infra/lib/linux/scaffolding.sh
@@ -5,7 +5,6 @@ fi
 
 scaffolding_load() {
   : "${scaffold_chef_client:=chef/chef-infra-client}"
-  : "${scaffold_chef_dk:=chef/chef-dk}"
   : "${scaffold_cacerts:=core/cacerts}"
   : "${scaffold_policyfile_path:=$PLAN_CONTEXT/../policyfiles}"
   : "${scaffold_data_bags_path:=$PLAN_CONTEXT/../data_bags}"
@@ -22,7 +21,6 @@ scaffolding_load() {
 
   pkg_build_deps=(
     "${pkg_build_deps[@]}"
-    "${scaffold_chef_dk}"
     "core/git"
   )
 
@@ -67,18 +65,18 @@ do_default_build() {
 
   for p in $(grep include_policy "${policyfile}" | awk -F "," '{print $1}' | awk -F '"' '{print $2}' | tr -d " "); do
     build_line "Detected included policyfile, ${p}.rb, installing"
-    chef install "${scaffold_policyfile_path}/${p}.rb"
+    chef-cli install "${scaffold_policyfile_path}/${p}.rb"
   done
   for p in $(grep include_policy "${policyfile}" | awk -F "," '{print $1}' | awk -F '\x27' '{print $2}' | tr -d " "); do
     build_line "Detected included policyfile, ${p}.rb, installing"
-    chef install "${scaffold_policyfile_path}/${p}.rb"
+    chef-cli install "${scaffold_policyfile_path}/${p}.rb"
   done
 
-  chef install "${policyfile}"
+  chef-cli install "${policyfile}"
 }
 
 do_default_install() {
-  chef export "${scaffold_policyfile_path}/${scaffold_policy_name}.lock.json" "${pkg_prefix}"
+  chef-cli export "${scaffold_policyfile_path}/${scaffold_policy_name}.lock.json" "${pkg_prefix}"
 
   mkdir -p "${pkg_prefix}/config"
 

--- a/scaffolding-chef-infra/plan.sh
+++ b/scaffolding-chef-infra/plan.sh
@@ -5,6 +5,19 @@ pkg_version=$(cat "${PLAN_CONTEXT}/../VERSION")
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_upstream_url="https://www.chef.sh"
+pkg_deps=(
+  core/git
+  core/ruby27
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=("vendor/bin")
+
+do_setup_environment() {
+  push_runtime_env GEM_PATH "$pkg_prefix/vendor"
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
+}
 
 do_download() {
   return 0
@@ -19,10 +32,12 @@ do_unpack() {
 }
 
 do_build() {
-  return 0
+  export GEM_HOME="${HAB_CACHE_SRC_PATH}/${pkg_dirname}/vendor"
+  gem install chef-cli --no-document
 }
 
 do_install() {
   mkdir -p "${pkg_prefix}/lib/linux"/
+  cp -r "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"/* ${pkg_prefix}
   cp -r "${PLAN_CONTEXT}/lib/linux"/* "${pkg_prefix}/lib"/
 }

--- a/scaffolding-chef-infra/plan.sh
+++ b/scaffolding-chef-infra/plan.sh
@@ -38,6 +38,6 @@ do_build() {
 
 do_install() {
   mkdir -p "${pkg_prefix}/lib/linux"/
-  cp -r "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"/* ${pkg_prefix}
+  cp -r "${HAB_CACHE_SRC_PATH}/${pkg_dirname}"/* "${pkg_prefix}"
   cp -r "${PLAN_CONTEXT}/lib/linux"/* "${pkg_prefix}/lib"/
 }


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This removes the dependency on the chef-dk for build and instead installs the chef-cli gem during the build of the scaffolding. 