### PR TITLE
Make run hook more portable by using single '='

### DIFF
--- a/scaffolding-chef-infra/lib/linux/run.bash
+++ b/scaffolding-chef-infra/lib/linux/run.bash
@@ -16,7 +16,7 @@ cfg_splay_first_run="${cfg_splay_first_run:-0}"
 cfg_chef_license={{cfg.chef_license.acceptance}}
 cfg_chef_license="${cfg_chef_license:-undefined}"
 
-if [ "${cfg_chef_license}" == "undefined" ]; then
+if [ "${cfg_chef_license}" = "undefined" ]; then
   cfg_chef_license_cmd=""
 else
   cfg_chef_license_cmd="--chef-license ${cfg_chef_license}"


### PR DESCRIPTION
Fixes #234 
Signed-off-by: gscho <greg.c.schofield@gmail.com>

