### PR TITLE
Feature/multi-profile

### DIFF
--- a/.expeditor/verify.scaffolding-chef-infra.yml
+++ b/.expeditor/verify.scaffolding-chef-infra.yml
@@ -104,9 +104,27 @@ steps:
           privileged: true
     timeout_in_minutes: 60
 
+  - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test default InSpec profile (multi-profile)"
+    command:
+      - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-default-profiles ci
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    timeout_in_minutes: 60
+
   - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test InSpec profile with API changes"
     command:
       - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-api ci
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    timeout_in_minutes: 60
+
+  - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test InSpec profile with API changes (multi-profile)"
+    command:
+      - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-api-profiles ci
     expeditor:
       executor:
         docker:
@@ -121,10 +139,28 @@ steps:
         docker:
           privileged: true
     timeout_in_minutes: 60
-  
+
+  - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test InSpec profile with waivers (multi-profile)"
+    command:
+      - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-waiver-profiles ci
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    timeout_in_minutes: 60
+
   - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test InSpec profile with inputs"
     command:
       - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-inputs ci
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    timeout_in_minutes: 60
+
+  - label: "[scaffolding-chef-inspec] :linux: :habicat: Run and test InSpec profile with inputs (multi-profile)"
+    command:
+      - bin/ci/verify-plans.sh scaffolding-chef-inspec user-linux-inputs-profiles ci
     expeditor:
       executor:
         docker:
@@ -143,12 +179,36 @@ steps:
           host_os: windows
           shell: [ "powershell", "-Command" ]
 
+  - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests default (multi-profile)"
+    env:
+      HAB_LICENSE: "accept-no-persist"
+      HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
+    command:
+      - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-default-profiles
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          shell: [ "powershell", "-Command" ]
+
   - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests api"
     env:
       HAB_LICENSE: "accept-no-persist"
       HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
     command:
       - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-api
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          shell: [ "powershell", "-Command" ]
+
+  - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests api (multi-profile)"
+    env:
+      HAB_LICENSE: "accept-no-persist"
+      HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
+    command:
+      - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-api-profiles
     expeditor:
       executor:
         docker:
@@ -167,12 +227,36 @@ steps:
           host_os: windows
           shell: [ "powershell", "-Command" ]
 
+  - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests waivers (multi-profile)"
+    env:
+      HAB_LICENSE: "accept-no-persist"
+      HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
+    command:
+      - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-waiver-profiles
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          shell: [ "powershell", "-Command" ]
+
   - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests inputs"
     env:
       HAB_LICENSE: "accept-no-persist"
       HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
     command:
       - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-inputs
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          shell: [ "powershell", "-Command" ]
+
+  - label: "[scaffolding-chef-inspec] :windows: :habicat: Build and run tests inputs (multi-profile)"
+    env:
+      HAB_LICENSE: "accept-no-persist"
+      HAB_STUDIO_SECRET_HAB_LICENSE: "accept-no-persist"
+    command:
+      - ./bin/ci/verify-plans.ps1 scaffolding-chef-inspec user-windows-inputs-profiles
     expeditor:
       executor:
         docker:

--- a/examples/effortless_audit/Readme.md
+++ b/examples/effortless_audit/Readme.md
@@ -2,13 +2,15 @@
 
 Effortless Audit is a way to package up your InSpec profiles into a Habitat Application allowing you to easily update them promote them through channels using Habitat Builder and be deterministic about the version of Inspec you are using with your profiles.
 
-## Introduction 
+## Introduction
 
 Welcome to the Effortless Audit Pattern! This set of examples provides an opinionated structure and usage methodology alongside documentation on the motivations for this pattern and it's typical usage.
 
 ## Directory Stucture
 
 This example demonstrates how to use the scaffolding to build a wrapper profile for a profile that is stored in Chef Automate. Since the profiles in automate are OS or platform specific this example is broken into two folders one for `Windows` and one for `Linux`. They are very similar and only differ in the source profiles they are wrapping.
+
+Also included is a reference for `linux-multi-profile` which includes the `scaffold_profiles` plan configuration option, showing how to include multiple discreet profiles in a single package.
 
 ## Requirements
 To configure and build a Effortless Audit application, you will need Habitat installed and configured on your development workstation. If you want to upload the package to Habitat Builder, you'll also need to have configured an origin and downloaded its keys into your local Habitat key cache.

--- a/examples/effortless_audit/linux-multi-profile/habitat/plan.sh
+++ b/examples/effortless_audit/linux-multi-profile/habitat/plan.sh
@@ -1,0 +1,12 @@
+pkg_name=effortless-a2-profile-test
+pkg_version=1.0.0
+pkg_origin=chef
+pkg_scaffolding="chef/scaffolding-chef-inspec"
+scaffold_automate_server_url=$AUTOMATE_SERVER_URL # Example: https://foo.bar.com
+scaffold_automate_user=$AUTOMATE_USER             # Example: "admin"
+scaffold_automate_token=$AUTOMATE_TOKEN           # Example: "DI0WVxInnyGnWKRlZBGizTXySgk="
+#scaffold_compliance_insecure=true                # set true to ignore SSL cert error when retrieving profile from A2
+scaffold_profiles=(
+  profile1
+  profile2
+)

--- a/examples/effortless_audit/linux-multi-profile/profile1/controls/example.rb
+++ b/examples/effortless_audit/linux-multi-profile/profile1/controls/example.rb
@@ -1,0 +1,5 @@
+title 'CIS Automate Test'
+
+include_controls 'cis-rhel7-level1-server' do
+  skip_control 'xccdf_org.cisecurity.benchmarks_rule_1.1.14_Ensure_nodev_option_set_on_home_partition'
+end

--- a/examples/effortless_audit/linux-multi-profile/profile1/inspec.yml
+++ b/examples/effortless_audit/linux-multi-profile/profile1/inspec.yml
@@ -1,0 +1,7 @@
+name: effortless-a2-profile-test-profile1
+title: Effortless Automate CIS profile Test
+version: 1.0.0
+
+depends:
+  - name: cis-rhel7-level1-server
+    compliance: admin/cis-rhel7-level1-server

--- a/examples/effortless_audit/linux-multi-profile/profile2/controls/example.rb
+++ b/examples/effortless_audit/linux-multi-profile/profile2/controls/example.rb
@@ -1,0 +1,5 @@
+title 'CIS Automate Test'
+
+include_controls 'cis-rhel7-level1-server' do
+  skip_control 'xccdf_org.cisecurity.benchmarks_rule_1.1.14_Ensure_nodev_option_set_on_home_partition'
+end

--- a/examples/effortless_audit/linux-multi-profile/profile2/inspec.yml
+++ b/examples/effortless_audit/linux-multi-profile/profile2/inspec.yml
@@ -1,0 +1,7 @@
+name: effortless-a2-profile-test-profile2
+title: Effortless Automate CIS profile Test
+version: 1.0.0
+
+depends:
+  - name: cis-rhel7-level1-server
+    compliance: admin/cis-rhel7-level1-server

--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -30,7 +30,7 @@ scaffolding_load() {
 
 do_default_before() {
   export CHEF_LICENSE="accept-no-persist"
-  # Check each profile specified (if multiple are included in scaffold_profile_list)
+  # Check each profile specified (if multiple are included in scaffold_profiles)
   for profile in ${scaffold_profiles[*]} ; do
     if [ ! -z $profile ] ;
     then

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/habitat/default.toml
@@ -1,0 +1,13 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[output]
+json = true
+
+[automate]
+enable = true
+server_url = "https://foo.com"
+token = "a;lskfj;alskjf"

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/habitat/plan.sh
@@ -1,7 +1,8 @@
-pkg_name=user-linux-default-profiles
+pkg_name=user-linux-api-profiles
 pkg_version=0.1.0
 pkg_origin=chef
 pkg_scaffolding="ci/scaffolding-chef-inspec"
+scaffold_inspec_client="chef/inspec/4.18.51"
 scaffold_profiles=(
   profile1
   profile2

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile1/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile1/controls/linux.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-api-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile2/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile2/controls/linux.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-api-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/tests/test.bats
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/tests/test.bats
@@ -1,0 +1,33 @@
+SCAFFOLD_PKG_INSPEC_CLIENT_VERSION="$(echo "${scaffold_inspec_client}" | cut -d/ -f3)"
+
+assert_file_exist() {
+  local -r file="$1"
+  if [[ ! -e "$file" ]]; then
+    fail
+  fi
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_FILE.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_DIR.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "API: scaffold_inspec_client version matches whats in the plan" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} inspec --version)"
+  [ "${result}" = "${SCAFFOLD_PKG_INSPEC_CLIENT_VERSION}" ]
+}
+
+@test "API: setting a json output creates a json file." {
+  assert_file_exist /hab/svc/${TEST_PKG_NAME}/results.json
+}
+
+teardown(){
+  if [ "${BATS_TEST_NUMBER}" -eq ${#BATS_TEST_NAMES[@]} ]; then
+    hab svc unload "${TEST_PKG_IDENT}" || true
+  fi
+}

--- a/scaffolding-chef-inspec/tests/user-linux-api-profiles/tests/test.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-api-profiles/tests/test.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh chef/scaffolding-chef-infra/1.2.0/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+TEST_PKG_NAME="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f2)"
+export TEST_PKG_NAME
+
+source "$(dirname "${0}")/../habitat/plan.sh"
+export pkg_svc_path
+export scaffold_inspec_client
+
+hab pkg install core/bats --binlink
+hab pkg install core/jq-static --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+SUP_WAIT_SECONDS=1
+
+hab sup term
+sleep "${SUP_WAIT_SECONDS}"
+echo "--- :habicat: Starting the supervisor"
+hab sup run &
+
+echo "Waiting ${SUP_WAIT_SECONDS} seconds for hab sup to start..."
+sleep "${SUP_WAIT_SECONDS}"
+
+LOAD_WAIT_SECONDS=10
+hab svc load "${TEST_PKG_IDENT}"
+echo "Waiting ${LOAD_WAIT_SECONDS} seconds for ${TEST_PKG_IDENT} to start..."
+
+sleep "${LOAD_WAIT_SECONDS}"
+bats "$(dirname "${0}")/test.bats"

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/habitat/plan.sh
@@ -1,0 +1,4 @@
+pkg_name=user-linux-default
+pkg_version=0.1.0
+pkg_origin=chef
+pkg_scaffolding="ci/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile1/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile1/controls/linux.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-default-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile2/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile2/controls/linux.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-default-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/tests/test.bats
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/tests/test.bats
@@ -1,0 +1,15 @@
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_FILE.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_DIR.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+teardown(){
+  if [ "${BATS_TEST_NUMBER}" -eq ${#BATS_TEST_NAMES[@]} ]; then
+    hab svc unload "${TEST_PKG_IDENT}" || true
+  fi
+}

--- a/scaffolding-chef-inspec/tests/user-linux-default-profiles/tests/test.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-default-profiles/tests/test.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh chef/scaffolding-chef-infra/1.2.0/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+TEST_PKG_NAME="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f2)"
+export TEST_PKG_NAME
+
+source "$(dirname "${0}")/../habitat/plan.sh"
+export pkg_svc_path
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+SUP_WAIT_SECONDS=1
+
+hab sup term
+sleep "${SUP_WAIT_SECONDS}"
+echo "--- :habicat: Starting the supervisor"
+hab sup run &
+
+echo "Waiting ${SUP_WAIT_SECONDS} seconds for hab sup to start..."
+sleep "${SUP_WAIT_SECONDS}"
+
+LOAD_WAIT_SECONDS=10
+hab svc load "${TEST_PKG_IDENT}"
+echo "Waiting ${LOAD_WAIT_SECONDS} seconds for ${TEST_PKG_IDENT} to start..."
+
+sleep "${LOAD_WAIT_SECONDS}"
+bats "$(dirname "${0}")/test.bats"

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/habitat/default.toml
@@ -1,0 +1,9 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[inputs]
+foo_2 = "foo_2 from input-file"
+foo_3 = 3

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=user-linux-default-profiles
+pkg_name=user-linux-inputs-profiles
 pkg_version=0.1.0
 pkg_origin=chef
 pkg_scaffolding="ci/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile1/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile1/controls/linux.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+input('foo_1', value: 'foo_1 defined in profile')
+input('foo_2', value: 'foo_2 defined in profile')
+input('foo_3', value: '0')
+
+control 'control_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test1') do
+    its("content"){ should match input('foo_1') }
+  end
+end
+
+control 'control_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test2') do
+    its("content"){ should match input('foo_2')}
+  end
+end
+
+
+control 'control_3' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test3') do
+    its("content"){ should cmp input('foo_3')}
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-waiver-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile2/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile2/controls/linux.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+input('foo_1', value: 'foo_1 defined in profile')
+input('foo_2', value: 'foo_2 defined in profile')
+input('foo_3', value: '0')
+
+control 'control_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test1') do
+    its("content"){ should match input('foo_1') }
+  end
+end
+
+control 'control_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test2') do
+    its("content"){ should match input('foo_2')}
+  end
+end
+
+
+control 'control_3' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test3') do
+    its("content"){ should cmp input('foo_3')}
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-waiver-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/tests/test.bats
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/tests/test.bats
@@ -1,0 +1,45 @@
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_FILE.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_DIR.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "Inputs: Ensure input file is written correctly" {
+  result="$(parse_yaml /hab/svc/${TEST_PKG_NAME}/config/inputs.yml | grep 'foo_2')"
+  echo ${result}
+  [ "${result}" = "foo_2=\"foo_2 from input-file\"" ]
+  
+  result="$(parse_yaml /hab/svc/${TEST_PKG_NAME}/config/inputs.yml | grep 'foo_3')"
+  [ "${result}" = "foo_3=\"3\"" ]
+}
+
+teardown(){
+  if [ "${BATS_TEST_NUMBER}" -eq ${#BATS_TEST_NAMES[@]} ]; then
+    hab svc unload "${TEST_PKG_IDENT}" || true
+    rm /tmp/test1
+    rm /tmp/test2
+    rm /tmp/test3
+  fi
+}

--- a/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/tests/test.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-inputs-profiles/tests/test.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh chef/scaffolding-chef-infra/1.2.0/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+TEST_PKG_NAME="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f2)"
+export TEST_PKG_NAME
+
+source "$(dirname "${0}")/../habitat/plan.sh"
+export pkg_svc_path
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+echo 'foo_1 defined in profile' > /tmp/test1
+echo 'foo_2 from input-file' > /tmp/test2
+echo '3' > /tmp/test3
+SUP_WAIT_SECONDS=1
+
+hab sup term
+sleep "${SUP_WAIT_SECONDS}"
+echo "--- :habicat: Starting the supervisor"
+hab sup run &
+
+echo "Waiting ${SUP_WAIT_SECONDS} seconds for hab sup to start..."
+sleep "${SUP_WAIT_SECONDS}"
+
+LOAD_WAIT_SECONDS=10
+hab svc load "${TEST_PKG_IDENT}"
+echo "Waiting ${LOAD_WAIT_SECONDS} seconds for ${TEST_PKG_IDENT} to start..."
+
+sleep "${LOAD_WAIT_SECONDS}"
+bats "$(dirname "${0}")/test.bats"

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/habitat/default.toml
@@ -1,0 +1,10 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[waivers]
+[waivers.foo_2]
+run = false
+justification = "This should be a test that foo_2 is skipped"

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/habitat/plan.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/habitat/plan.sh
@@ -1,4 +1,4 @@
-pkg_name=user-linux-default-profiles
+pkg_name=user-linux-waiver-profiles
 pkg_version=0.1.0
 pkg_origin=chef
 pkg_scaffolding="ci/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile1/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile1/controls/linux.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'foo_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end
+
+control 'foo_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-waiver-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile2/controls/linux.rb
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile2/controls/linux.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'foo_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end
+
+control 'foo_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-linux-waiver-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/tests/test.bats
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/tests/test.bats
@@ -1,0 +1,37 @@
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_FILE.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "API: scaffold_cacerts matches run hook core/cacerts" {
+  result="$(grep '^export SSL_CERT_DIR.*' /hab/svc/${TEST_PKG_NAME}/hooks/run | cut -d/ -f4-5)"
+  [ "${result}" = "core/cacerts" ]
+}
+
+@test "Waiver: Ensure waiver file is written correctly" {
+  result="$(parse_yaml /hab/svc/user-linux-waiver/config/waiver.yml | grep 'foo_2_run')"
+  [ "${result}" = "foo_2_run=\"false\"" ]
+}
+
+teardown(){
+  if [ "${BATS_TEST_NUMBER}" -eq ${#BATS_TEST_NAMES[@]} ]; then
+    hab svc unload "${TEST_PKG_IDENT}" || true
+  fi
+}

--- a/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/tests/test.sh
+++ b/scaffolding-chef-inspec/tests/user-linux-waiver-profiles/tests/test.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh chef/scaffolding-chef-infra/1.2.0/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+TEST_PKG_NAME="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f2)"
+export TEST_PKG_NAME
+
+source "$(dirname "${0}")/../habitat/plan.sh"
+export pkg_svc_path
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+SUP_WAIT_SECONDS=1
+
+hab sup term
+sleep "${SUP_WAIT_SECONDS}"
+echo "--- :habicat: Starting the supervisor"
+hab sup run &
+
+echo "Waiting ${SUP_WAIT_SECONDS} seconds for hab sup to start..."
+sleep "${SUP_WAIT_SECONDS}"
+
+LOAD_WAIT_SECONDS=10
+hab svc load "${TEST_PKG_IDENT}"
+echo "Waiting ${LOAD_WAIT_SECONDS} seconds for ${TEST_PKG_IDENT} to start..."
+
+sleep "${LOAD_WAIT_SECONDS}"
+bats "$(dirname "${0}")/test.bats"

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/habitat/default.toml
@@ -1,0 +1,13 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[output]
+json = true
+
+[automate]
+enable = true
+server_url = "https://foo.com"
+token = "a;lskfj;alskjf"

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/habitat/plan.ps1
@@ -1,7 +1,8 @@
-$pkg_name="user-windows-default-profiles"
+$pkg_name="user-windows-api"
 $pkg_version="0.1.0"
 $pkg_origin="ci"
 $pkg_scaffolding="ci/scaffolding-chef-inspec"
+$scaffold_inspec_client="chef/inspec/4.18.39"
 $scaffold_profiles=@(
   "profile1",
   "profile2"

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile1/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile1/controls/windows.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-default-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile2/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile2/controls/windows.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-default-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/tests/test.pester.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/tests/test.pester.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+Describe "Inspec client run doesn't fail" {
+    AfterAll {
+        hab svc unload $PackageIdentifier
+        Remove-Item "c:/temp" -Recurse -ErrorAction SilentlyContinue
+    }
+
+    Context "API: scaffold_cacerts matches run hook core/cacerts" {
+        It "SSL_CERT_FILE should be core/cacerts" {
+            $cert_file = Get-Content "C:\hab\svc\user-windows-api\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_FILE'
+            $cert_file = $cert_file -split '='
+            $cert_file = $cert_file[1].split('\')
+            $cert_pkg = $cert_file[3] + '/' + $cert_file[4]
+
+            $cert_pkg | Should be "core/cacerts"
+        }
+        It "SSL_CERT_DIR should be core/cacerts" {
+            $cert_dir = Get-Content "C:\hab\svc\user-windows-api\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_DIR'
+            $cert_dir = $cert_dir -split '='
+            $cert_dir = $cert_dir[1].split('\')
+            $cert_pkg_dir = $cert_dir[3] + '/' + $cert_dir[4]
+
+            $cert_pkg_dir | Should be "core/cacerts"
+        }
+    }
+
+    Context "API: there is a results.json file" {
+        It "The inspec should be the official inspec client" {
+            $result_json = Test-Path "C:\hab\svc\user-windows-api\results.json"
+            $result_json | Should be $true
+        }
+    }
+}

--- a/scaffolding-chef-inspec/tests/user-windows-api-profiles/tests/test.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-api-profiles/tests/test.ps1
@@ -1,0 +1,39 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929"),
+    [string]$PackageSource = $(throw "Usage: test.ps1 [test_pkg_source] e.g. test.ps1 ./results/ci-user-windows-1.0.0-20190812103929-x86_64-windows.hart")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)){
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+Write-Output ""
+Write-Output $env:PATH
+Write-Output ""
+
+# Install the package
+hab pkg install $PackageSource
+
+Get-Process hab-launch -ErrorAction SilentlyContinue | Stop-Process
+
+$SUP_WAIT_SECONDS = 60
+
+Start-Sleep $SUP_WAIT_SECONDS
+$hab_supervisor = Start-Process hab -ArgumentList sup,run -NoNewWindow -PassThru
+Write-Output "Waiting $SUP_WAIT_SECONDS seconds for hab sup to start..."
+Start-Sleep $SUP_WAIT_SECONDS
+
+$LOAD_WAIT_SECONDS = 60
+
+Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start..."
+hab svc load $PackageIdentifier
+Start-Sleep $LOAD_WAIT_SECONDS
+
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/habitat/default.toml
@@ -1,0 +1,5 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/habitat/plan.ps1
@@ -1,0 +1,8 @@
+$pkg_name="user-windows-default"
+$pkg_version="0.1.0"
+$pkg_origin="ci"
+$pkg_scaffolding="ci/scaffolding-chef-inspec"
+$scaffold_profiles=@(
+  "profile1",
+  "profile2"
+)

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile1/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile1/controls/windows.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-default-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile2/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile2/controls/windows.rb
@@ -1,0 +1,11 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'Test Control' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-default-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Linux Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/tests/test.pester.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/tests/test.pester.ps1
@@ -1,0 +1,30 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+Describe "Inspec client run doesn't fail" {
+    AfterAll {
+        hab svc unload $PackageIdentifier
+        Remove-Item "c:/temp" -Recurse -ErrorAction SilentlyContinue
+    }
+
+    Context "API: scaffold_cacerts matches run hook core/cacerts" {
+        It "SSL_CERT_FILE should be core/cacerts" {
+            $cert_file = Get-Content "C:\hab\svc\user-windows-default\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_FILE'
+            $cert_file = $cert_file -split '='
+            $cert_file = $cert_file[1].split('\')
+            $cert_pkg = $cert_file[3] + '/' + $cert_file[4]
+
+            $cert_pkg | Should be "core/cacerts"
+        }
+        It "SSL_CERT_DIR should be core/cacerts" {
+            $cert_dir = Get-Content "C:\hab\svc\user-windows-default\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_DIR'
+            $cert_dir = $cert_dir -split '='
+            $cert_dir = $cert_dir[1].split('\')
+            $cert_pkg_dir = $cert_dir[3] + '/' + $cert_dir[4]
+
+            $cert_pkg_dir | Should be "core/cacerts"
+        }
+    }
+}

--- a/scaffolding-chef-inspec/tests/user-windows-default-profiles/tests/test.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-default-profiles/tests/test.ps1
@@ -1,0 +1,35 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929"),
+    [string]$PackageSource = $(throw "Usage: test.ps1 [test_pkg_source] e.g. test.ps1 ./results/ci-user-windows-1.0.0-20190812103929-x86_64-windows.hart")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)){
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageSource
+
+Get-Process hab-launch -ErrorAction SilentlyContinue | Stop-Process
+
+$SUP_WAIT_SECONDS = 60
+
+Start-Sleep $SUP_WAIT_SECONDS
+$hab_supervisor = Start-Process hab -ArgumentList sup,run -NoNewWindow -PassThru
+Write-Output "Waiting $SUP_WAIT_SECONDS seconds for hab sup to start..."
+Start-Sleep $SUP_WAIT_SECONDS
+
+$LOAD_WAIT_SECONDS = 60
+
+Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start..."
+hab svc load $PackageIdentifier
+Start-Sleep $LOAD_WAIT_SECONDS
+
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/habitat/default.toml
@@ -1,0 +1,9 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[inputs]
+foo_2 = "foo_2 from input-file"
+foo_3 = 3

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/habitat/plan.ps1
@@ -1,4 +1,4 @@
-$pkg_name="user-windows-default-profiles"
+$pkg_name="user-windows-inputs-profiles"
 $pkg_version="0.1.0"
 $pkg_origin="ci"
 $pkg_scaffolding="ci/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile1/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile1/controls/windows.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+input('foo_1', value: 'foo_1 defined in profile')
+input('foo_2', value: 'foo_2 defined in profile')
+input('foo_3', value: '0')
+
+control 'control_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test1') do
+    its("content"){ should match input('foo_1') }
+  end
+end
+
+control 'control_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test2') do
+    its("content"){ should match input('foo_2')}
+  end
+end
+
+
+control 'control_3' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test3') do
+    its("content"){ should cmp input('foo_3')}
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-waiver-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Windows Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile2/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile2/controls/windows.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+input('foo_1', value: 'foo_1 defined in profile')
+input('foo_2', value: 'foo_2 defined in profile')
+input('foo_3', value: '0')
+
+control 'control_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test1') do
+    its("content"){ should match input('foo_1') }
+  end
+end
+
+control 'control_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test2') do
+    its("content"){ should match input('foo_2')}
+  end
+end
+
+
+control 'control_3' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('\test3') do
+    its("content"){ should cmp input('foo_3')}
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-waiver-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Windows Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/tests/test.pester.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/tests/test.pester.ps1
@@ -1,0 +1,29 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+Describe "Inspec client run doesn't fail" {
+    AfterAll {
+        hab svc unload $PackageIdentifier
+    }
+
+    Context "API: scaffold_cacerts matches run hook core/cacerts" {
+        It "SSL_CERT_FILE should be core/cacerts" {
+            $cert_file = Get-Content "C:\hab\svc\user-windows-inputs\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_FILE'
+            $cert_file = $cert_file -split '='
+            $cert_file = $cert_file[1].split('\')
+            $cert_pkg = $cert_file[3] + '/' + $cert_file[4]
+
+            $cert_pkg | Should be "core/cacerts"
+        }
+    }
+
+    Context "Inputs: the yaml renders" {
+        It "The inputs.yml has correct foo_2 and foo_3 inputs" {
+            $yaml = Get-Content "C:\hab\svc\user-windows-inputs\config\inputs.yml"
+            $yaml[1] | Should be "foo_2: foo_2 from input-file"
+            $yaml[2] | Should be "foo_3: 3"
+        }
+    }
+}

--- a/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/tests/test.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-inputs-profiles/tests/test.ps1
@@ -1,0 +1,40 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929"),
+    [string]$PackageSource = $(throw "Usage: test.ps1 [test_pkg_source] e.g. test.ps1 ./results/ci-user-windows-1.0.0-20190812103929-x86_64-windows.hart")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)){
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Setup teest files
+set-content \test1 -value "foo_1 defined in profile"
+set-content \test2 -value "foo_2 from input-file"
+set-content \test3 -value "3"
+
+# Install the package
+hab pkg install $PackageSource
+
+Get-Process hab-launch -ErrorAction SilentlyContinue | Stop-Process
+
+$SUP_WAIT_SECONDS = 60
+
+Start-Sleep $SUP_WAIT_SECONDS
+$hab_supervisor = Start-Process hab -ArgumentList sup,run -NoNewWindow -PassThru
+Write-Output "Waiting $SUP_WAIT_SECONDS seconds for hab sup to start..."
+Start-Sleep $SUP_WAIT_SECONDS
+
+$LOAD_WAIT_SECONDS = 60
+
+Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start..."
+hab svc load $PackageIdentifier
+Start-Sleep $LOAD_WAIT_SECONDS
+
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/habitat/default.toml
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/habitat/default.toml
@@ -1,0 +1,10 @@
+# You must accept the Chef License to use this software: https://www.chef.io/end-user-license-agreement/
+# Change [chef_license] from acceptance = "undefined" to acceptance = "accept-no-persist" if you agree to the license.
+
+[chef_license]
+acceptance = "accept-no-persist"
+
+[waivers]
+[waivers.foo_2]
+run = false
+justification = "This should be a test that foo_2 is skipped"

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/habitat/plan.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/habitat/plan.ps1
@@ -1,4 +1,4 @@
-$pkg_name="user-windows-default-profiles"
+$pkg_name="user-windows-waiver-profiles"
 $pkg_version="0.1.0"
 $pkg_origin="ci"
 $pkg_scaffolding="ci/scaffolding-chef-inspec"

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile1/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile1/controls/windows.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'foo_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end
+
+control 'foo_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile1/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile1/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-waiver-profile1
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Windows Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile2/controls/windows.rb
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile2/controls/windows.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+# copyright: 2018, The Authors
+
+control 'foo_1' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end
+
+control 'foo_2' do
+  title 'Control title'
+  desc "Control description"
+  impact 1.0
+  describe file('c:/tmp/test') do
+    it { should_not exist }
+  end
+end

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile2/inspec.yml
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/profile2/inspec.yml
@@ -1,0 +1,8 @@
+name: user-windows-waiver-profile2
+title: Effortless Audit with default plan settings
+maintainer: CCP Team
+copyright: CCP Team
+copyright_email: you@example.com
+license: Apache-2.0
+summary: Effortless Audit Windows Baseline
+version: 0.1.0

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/tests/test.pester.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/tests/test.pester.ps1
@@ -1,0 +1,28 @@
+param(
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows-default/1.0.0/20190812103929")
+)
+
+Describe "Inspec client run doesn't fail" {
+    AfterAll {
+        hab svc unload $PackageIdentifier
+    }
+
+    Context "API: scaffold_cacerts matches run hook core/cacerts" {
+        It "SSL_CERT_FILE should be core/cacerts" {
+            $cert_file = Get-Content "C:\hab\svc\user-windows-waiver\hooks\run" | Select-String -Pattern '\$env:SSL_CERT_FILE'
+            $cert_file = $cert_file -split '='
+            $cert_file = $cert_file[1].split('\')
+            $cert_pkg = $cert_file[3] + '/' + $cert_file[4]
+
+            $cert_pkg | Should be "core/cacerts"
+        }
+    }
+
+    Context "Waiver: the yaml renders" {
+        It "The waiver.yml has a foo_2 control" {
+            $yaml = Get-Content "C:\hab\svc\user-windows-waiver\config\waiver.yml"
+            $yaml[1] | Should be "foo_2:"
+        }
+    }
+}

--- a/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/tests/test.ps1
+++ b/scaffolding-chef-inspec/tests/user-windows-waiver-profiles/tests/test.ps1
@@ -1,0 +1,35 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pkg_ident] e.g. test.ps1 ci/user-windows/1.0.0/20190812103929"),
+    [string]$PackageSource = $(throw "Usage: test.ps1 [test_pkg_source] e.g. test.ps1 ./results/ci-user-windows-1.0.0-20190812103929-x86_64-windows.hart")
+)
+
+if (-Not (Get-Module -ListAvailable -Name Pester)){
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageSource
+
+Get-Process hab-launch -ErrorAction SilentlyContinue | Stop-Process
+
+$SUP_WAIT_SECONDS = 60
+
+Start-Sleep $SUP_WAIT_SECONDS
+$hab_supervisor = Start-Process hab -ArgumentList sup,run -NoNewWindow -PassThru
+Write-Output "Waiting $SUP_WAIT_SECONDS seconds for hab sup to start..."
+Start-Sleep $SUP_WAIT_SECONDS
+
+$LOAD_WAIT_SECONDS = 60
+
+Write-Output "Waiting $LOAD_WAIT_SECONDS seconds for $PackageIdentifier to start..."
+hab svc load $PackageIdentifier
+Start-Sleep $LOAD_WAIT_SECONDS
+
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -Strict -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount


### PR DESCRIPTION
Allows for the inclusion of multiple Inspec profiles for the Effortless package, specified as directory names with `scaffold_profiles`.

Currently when running multiple Effortless Inspec packages on a node, only the latest package to send result data will have results showing in the UI for Automate.  To work around this a wrapper profile can be used, but then all controls show up under a potentially monolithic profile.

These changes add the ability to include multiple profiles in a single Effortless Inspec package, each of which will have results populated to Automate as discreet profiles.