### PR TITLE
Prep effortless docs so they can be added to docs.chef.io

### DIFF
--- a/effortless-chef-io/content/effortless/_index.md
+++ b/effortless-chef-io/content/effortless/_index.md
@@ -1,3 +1,15 @@
++++
+title = "Effortless Overview"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "Effortless Overview"
+    identifier = "effortless/_index.md Overview"
+    parent = "effortless"
+    weight = 10
++++
+
 # Welcome to the Chef Effortless Patterns
 
 The Effortless Pattern is a way to better manage Chef Infra and Chef InSpec workloads using Chef Habitat, and to visualize your fleet using Chef Automate. We believe that each of these technologies working together can help you better manage your infrastructure.

--- a/effortless-chef-io/content/effortless/effortless_audit.md
+++ b/effortless-chef-io/content/effortless/effortless_audit.md
@@ -1,3 +1,16 @@
++++
+title = "Effortless Audit"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "Effortless Audit"
+    identifier = "effortless/effortless_audit.md Effortless Audit"
+    parent = "effortless"
+    weight = 20
++++
+
+
 # Effortless Audit
 
 Effortless Audit is the pattern for managing your Chef InSpec profiles. It uses [Chef Habitat](https://www.habitat.sh/docs/) and [Chef InSpec](https://www.inspec.io/docs/) to build an artifact that contains your profiles and its dependencies alongside the scripts necessary to run them on your systems.

--- a/effortless-chef-io/content/effortless/effortless_config.md
+++ b/effortless-chef-io/content/effortless/effortless_config.md
@@ -1,3 +1,15 @@
++++
+title = "Effortless Config"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "Effortless Config"
+    identifier = "effortless/effortless_config.md Effortless config"
+    parent = "effortless"
+    weight = 30
++++
+
 # Effortless Config
 
 Effortless Config is the pattern for managing your Chef Infra workloads. It uses [Chef Habitat](https://www.habitat.sh/docs/) and [Chef Policyfiles](https://docs.chef.io/policyfile/) to build an artifact that contains the cookbooks and their dependencies alongside the scripts necessary to run them on your systems.

--- a/effortless-chef-io/content/effortless/quick_start.md
+++ b/effortless-chef-io/content/effortless/quick_start.md
@@ -1,3 +1,16 @@
++++
+title = "Effortless Quick Start"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "Quick Start"
+    identifier = "effortless/quick_start.md Quick Start"
+    parent = "effortless"
+    weight = 10
++++
+
+
 # Quick Start
 
 This is a quick guide on how to get started with Effortless.

--- a/effortless-chef-io/content/effortless/variables_and_config.md
+++ b/effortless-chef-io/content/effortless/variables_and_config.md
@@ -1,3 +1,15 @@
++++
+title = "Effortless Variables and Config"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "Variables and Config"
+    identifier = "effortless/variables_and_config.md Effortless Variables and Config"
+    parent = "effortless"
+    weight = 40
++++
+
 # Plan Variables and Chef Habitat Configurations
 
 This documents the options for both your plan and your `habitat` configuration file.

--- a/effortless-chef-io/content/effortless/what_is_scaffolding.md
+++ b/effortless-chef-io/content/effortless/what_is_scaffolding.md
@@ -1,3 +1,15 @@
++++
+title = "Effortless What is Scaffolding"
+draft = false
+
+[menu]
+  [menu.effortless]
+    title = "What is Scaffolding"
+    identifier = "effortless/what_is_scaffolding.md Effortless What is Scaffolding"
+    parent = "effortless"
+    weight = 50
++++
+
 # Chef Habitat Scaffolding
 
 Chef Habitat scaffolding is a way to build a Chef Habitat plan that overrides some of the default functions that Chef Habitat uses during its build process. You can find out more about [scaffolding](https://www.habitat.sh/docs/glossary/#sts=Scaffolding) in the Chef Habitat documentation.

--- a/effortless-chef-io/go.mod
+++ b/effortless-chef-io/go.mod
@@ -1,0 +1,3 @@
+module github.com/chef/effortless/effortless-chef-io
+
+go 1.14


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

This preps the docs in effortless-chef-io so they can be added as a [Hugo module](https://gohugo.io/hugo-modules/) to docs.chef.io

- moves MD files from `effortless-chef-io` to `effortless-chef-io/content/effortless`
- renames files so they use underscores instead of dashes
- adds go.mod file so Hugo can find the content
- adds page/menu metadata to each MD file