### PR TITLE
added . for plan context for hab pkg build command

### DIFF
--- a/effortless-chef-io/content/effortless/effortless_audit.md
+++ b/effortless-chef-io/content/effortless/effortless_audit.md
@@ -78,7 +78,7 @@ In Chef InSpec, a common pattern is to write a wrapper profile that depends on a
    Run the following command to build the package:
 
    ```bash
-   hab pkg build
+   hab pkg build .
    ```
 
 1. Add a `kitchen.yml` file to your profile with the following content:

--- a/effortless-chef-io/content/effortless/effortless_config.md
+++ b/effortless-chef-io/content/effortless/effortless_config.md
@@ -111,7 +111,7 @@ The Chef Effortless GitHub repository has an [example chef-repo](https://github.
    Run the following command to build the package:
 
    ```bash
-   hab pkg build
+   hab pkg build .
    ```
 
 1. Edit the `kitchen.yml` file to look similar to this:


### PR DESCRIPTION
Minor tweak to the docs.  When walking through the docs to try it all out, noticed that the `hab pkg build` command was missing plan context in a couple of places and using the command as written would not work even while in the directory where the plan.sh resides.

Signed-off-by: kenlangdon <klangdon@chef.io>

