### PR TITLE
Support for node_uuid so you can reuse existing nodes in Automate

### DIFF
--- a/scaffolding-chef-inspec/lib/scaffolding.sh
+++ b/scaffolding-chef-inspec/lib/scaffolding.sh
@@ -205,7 +205,8 @@ EOF
         "token": "{{cfg.automate.token}}",
         "node_name": "{{ sys.hostname }}",
         "verify_ssl": false{{#if cfg.automate.environment}},
-        "environment": "{{cfg.automate.environment}}"{{/if }}
+        "environment": "{{cfg.automate.environment}}"{{/if }}{{#if cfg.automate.node_uuid}},
+        "node_uuid": "{{cfg.automate.node_uuid}}"{{/if }}
       }{{/if }}
     }
 }


### PR DESCRIPTION
If you are using the Habitat cookbook and pass a block like this
```
hab_config 'effortless-audit.default' do
  config({
          automate: {
                     enable: true,
                     server_url: 'https://example.com',
                     token: 'fZ7HwczDoFkIljIQvhFiE22YRO4=',
                     environment: 'effortless',
                     node_uuid: node['chef_guid'],
                    },
         })
end
```
you can migrate nodes from the Audit cookbook and keep their Automate history.

Signed-off-by: Matt Ray <github@mattray.dev>

