### PR TITLE
update bootstrap to simplify package name capturing

### DIFF
--- a/docs-chef-io/content/effortless/effortless_config.md
+++ b/docs-chef-io/content/effortless/effortless_config.md
@@ -171,7 +171,7 @@ The Chef Effortless GitHub repository has an [example chef-repo](https://github.
 
    echo "Starting $pkg_origin/$pkg_name"
 
-   latest_hart_file=$(ls -la /tmp/results/$pkg_origin-$pkg_name* | tail -n 1 | cut -d " " -f 9)
+   latest_hart_file=$(ls -1 /tmp/results/$pkg_origin-$pkg_name*)
    echo "Latest hart file is $latest_hart_file"
 
    echo "Installing $latest_hart_file"
@@ -182,9 +182,17 @@ The Chef Effortless GitHub repository has an [example chef-repo](https://github.
 
    echo "Found $pkg_prefix"
 
+   echo "{\"bootstrap_mode\": true}" > /tmp/results/bootstrap.json
+
    echo "Running chef for $pkg_origin/$pkg_name"
    cd $pkg_prefix
-   hab pkg exec $pkg_origin/$pkg_name chef-client -z -c $pkg_prefix/config/bootstrap-config.rb
+   if [ -n "$bootstrap" ]; then
+     hab pkg exec $pkg_origin/$pkg_name chef-client -z -j /tmp/results/bootstrap.json -c $pkg_prefix/config/bootstrap-config.rb
+   else
+     hab pkg exec $pkg_origin/$pkg_name chef-client -z -c $pkg_prefix/config/bootstrap-config.rb
+   fi
+
+   rm /tmp/results/bootstrap.json
    ```
 
 1. Run Test Kitchen to ensure the cookbook works
@@ -350,9 +358,17 @@ This pattern builds a Chef Habitat artifact for the Policyfile cookbook. You can
 
    echo "Found $pkg_prefix"
 
+   echo "{\"bootstrap_mode\": true}" > /tmp/results/bootstrap.json
+
    echo "Running chef for $pkg_origin/$pkg_name"
    cd $pkg_prefix
-   hab pkg exec $pkg_origin/$pkg_name chef-client -z -c $pkg_prefix/config/bootstrap-config.rb
+   if [ -n "$bootstrap" ]; then
+     hab pkg exec $pkg_origin/$pkg_name chef-client -z -j /tmp/results/bootstrap.json -c $pkg_prefix/config/bootstrap-config.rb
+   else
+     hab pkg exec $pkg_origin/$pkg_name chef-client -z -c $pkg_prefix/config/bootstrap-config.rb
+   fi
+
+   rm /tmp/results/bootstrap.json
    ```
 
 1. Run Test Kitchen to ensure the cookbook works on Linux

--- a/examples/effortless_config/chef_repo_pattern/bootstrap.sh
+++ b/examples/effortless_config/chef_repo_pattern/bootstrap.sh
@@ -23,7 +23,7 @@ pkg_name=$2
 
 echo "Starting $pkg_origin/$pkg_name"
 
-latest_hart_file=$(ls -la /tmp/results/$pkg_origin-$pkg_name* | tail -n 1 | cut -d " " -f 10)
+latest_hart_file=$(ls -1 /tmp/results/$pkg_origin-$pkg_name* | tail -n 1)
 echo "Latest hart file is $latest_hart_file"
 
 echo "Installing $latest_hart_file"

--- a/examples/effortless_config/policyfile_cookbook_pattern/bootstrap.sh
+++ b/examples/effortless_config/policyfile_cookbook_pattern/bootstrap.sh
@@ -23,7 +23,7 @@ pkg_name=$2
 
 echo "Starting $pkg_origin/$pkg_name"
 
-latest_hart_file=$(ls -la /tmp/results/$pkg_origin-$pkg_name* | tail -n 1 | cut -d " " -f 10)
+latest_hart_file=$(ls -1 /tmp/results/$pkg_origin-$pkg_name* | tail -n 1)
 echo "Latest hart file is $latest_hart_file"
 
 echo "Installing $latest_hart_file"


### PR DESCRIPTION
This updates the ls command to get the latest package file
from the results directory to use ls -1 instead of parsing
the ls output with cut.

Also includes a few documentation fixes to bring those 
docs up-to-date with what is in the example directory.

Signed-off-by: Mark Bainter <mbainter@gmail.com>

