### PR TITLE
Fix bad links, use relref, and replace "Edit on Github" links with partial

### DIFF
--- a/docs-chef-io/config.toml
+++ b/docs-chef-io/config.toml
@@ -1,0 +1,2 @@
+[params.effortless]
+gh_path = "https://github.com/chef/effortless/tree/master/docs-chef-io/content/"

--- a/docs-chef-io/content/effortless/_index.md
+++ b/docs-chef-io/content/effortless/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless Overview"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -9,8 +10,6 @@ draft = false
     parent = "effortless"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/_index.md)
 
 # Welcome to the Chef Effortless Patterns
 
@@ -26,7 +25,7 @@ If you use Chef Infra or Chef InSpec to manage your operating system configs, yo
   * Effortless does not support situations that require a Chef Infra Server. For example, if you use search in your cookbooks, or use `chef vault` for secrets management, then Effortless will not work for those cookbooks
   * If you have complex applications, you should deploy them with Chef Habitat as it has more features that better support complex applications
 
-* If you have a bunch of nested cookbooks or Policyfiles in a complex [Chef Roles](https://docs.chef.io/roles/) and [Chef Environments](https://docs.chef.io/environments/) setup, you may not want to move to Effortless.
+* If you have a bunch of nested cookbooks or Policyfiles in a complex [Chef Roles]({{< relref "/roles" >}}) and [Chef Environments]({{< relref "/environments" >}}) setup, you may not want to move to Effortless.
   * When you have a base cookbook and a bunch of Applications cookbooks dependent on that base cookbook, managing the build graph can become difficult because a change to the base cookbook will require a build to all the application cookbooks. Effortless in this situation can quickly become difficult to manage.
 
 ## Purpose

--- a/docs-chef-io/content/effortless/effortless_audit.md
+++ b/docs-chef-io/content/effortless/effortless_audit.md
@@ -14,14 +14,14 @@ draft = false
 
 # Effortless Audit
 
-Effortless Audit is the pattern for managing your Chef InSpec profiles. It uses [Chef Habitat](https://www.habitat.sh/docs/) and [Chef InSpec](/inspec/) to build an artifact that contains your profiles and its dependencies alongside the scripts necessary to run them on your systems.
+Effortless Audit is the pattern for managing your Chef InSpec profiles. It uses [Chef Habitat](/habitat/) and [Chef InSpec](/inspec/) to build an artifact that contains your profiles and its dependencies alongside the scripts necessary to run them on your systems.
 
 Learn more about [Chef InSpec profiles](/inspec/profiles/).
 
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](https://www.habitat.sh/docs/install-habitat/)
+1. Install [Chef Habitat](/habitat/install_habitat/)
 1. Configure Chef Habitat on your workstation by running `hab setup`
 
 ## Patterns
@@ -161,7 +161,7 @@ In Chef InSpec, a common pattern is to write a wrapper profile that depends on a
    kitchen converge base-centos
    ```
 
-   If you experience failures when running the profile, know that most basic virtual machines are not fully hardened to your security policies. If you want to fix the failures, look at [Chef Infra and the Effortless Config Pattern](effortless-config.md).
+   If you experience failures when running the profile, know that most basic virtual machines are not fully hardened to your security policies. If you want to fix the failures, look at [Chef Infra and the Effortless Config Pattern]({{< relref "effortless_config" >}}).
 
 1. When ready, delete the VM instance by running:
 

--- a/docs-chef-io/content/effortless/effortless_audit.md
+++ b/docs-chef-io/content/effortless/effortless_audit.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless Audit"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -10,25 +11,23 @@ draft = false
     weight = 20
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/effortless_audit.md)
-
 # Effortless Audit
 
-Effortless Audit is the pattern for managing your Chef InSpec profiles. It uses [Chef Habitat](/habitat/) and [Chef InSpec](/inspec/) to build an artifact that contains your profiles and its dependencies alongside the scripts necessary to run them on your systems.
+Effortless Audit is the pattern for managing your Chef InSpec profiles. It uses [Chef Habitat]({{< relref "/habitat/" >}}) and [Chef InSpec]({{< relref "/inspec/" >}}) to build an artifact that contains your profiles and its dependencies alongside the scripts necessary to run them on your systems.
 
-Learn more about [Chef InSpec profiles](/inspec/profiles/).
+Learn more about [Chef InSpec profiles]({{< relref "/inspec/profiles" >}}).
 
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](/habitat/install_habitat/)
+1. Install [Chef Habitat]({{< relref "/habitat/install_habitat" >}})
 1. Configure Chef Habitat on your workstation by running `hab setup`
 
 ## Patterns
 
 ### Wrapper Profile Pattern
 
-In Chef InSpec, a common pattern is to write a wrapper profile that depends on another profile. This pattern pulls profiles from a main profile source like the [Chef Automate Profile Store](https://automate.chef.io/docs/profiles/). See an [example of this pattern](https://github.com/chef/effortless/tree/master/examples/effortless_audit).
+In Chef InSpec, a common pattern is to write a wrapper profile that depends on another profile. This pattern pulls profiles from a main profile source like the [Chef Automate Profile Store]({{< relref "/automate/profiles" >}}). See an [example of this pattern](https://github.com/chef/effortless/tree/master/examples/effortless_audit).
 
 1. To use this pattern, navigate to your profile:
 

--- a/docs-chef-io/content/effortless/effortless_config.md
+++ b/docs-chef-io/content/effortless/effortless_config.md
@@ -14,12 +14,12 @@ draft = false
 
 # Effortless Config
 
-Effortless Config is the pattern for managing your Chef Infra workloads. It uses [Chef Habitat](https://www.habitat.sh/docs/) and [Chef Policyfiles](https://docs.chef.io/policyfile/) to build an artifact that contains the cookbooks and their dependencies alongside the scripts necessary to run them on your systems.
+Effortless Config is the pattern for managing your Chef Infra workloads. It uses [Chef Habitat](/habitat/) and [Chef Policyfiles](/policyfile/) to build an artifact that contains the cookbooks and their dependencies alongside the scripts necessary to run them on your systems.
 
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](https://www.habitat.sh/docs/install-habitat/)
+1. Install [Chef Habitat](/habitat/install_habitat/)
 1. Configure Chef Habitat on your workstation by running `hab setup`
 
 ## Patterns

--- a/docs-chef-io/content/effortless/effortless_config.md
+++ b/docs-chef-io/content/effortless/effortless_config.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless Config"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -10,23 +11,21 @@ draft = false
     weight = 30
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/effortless_config.md)
-
 # Effortless Config
 
-Effortless Config is the pattern for managing your Chef Infra workloads. It uses [Chef Habitat](/habitat/) and [Chef Policyfiles](/policyfile/) to build an artifact that contains the cookbooks and their dependencies alongside the scripts necessary to run them on your systems.
+Effortless Config is the pattern for managing your Chef Infra workloads. It uses [Chef Habitat]({{< relref "/habitat" >}}) and [Chef Policyfiles]({{< relref "/policyfile" >}}) to build an artifact that contains the cookbooks and their dependencies alongside the scripts necessary to run them on your systems.
 
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](/habitat/install_habitat/)
+1. Install [Chef Habitat]({{< relref "/habitat/install_habitat" >}})
 1. Configure Chef Habitat on your workstation by running `hab setup`
 
 ## Patterns
 
 ### Chef Repo Cookbook Pattern
 
-This pattern uses the [chef-repo](https://docs.chef.io/chef_repo/) to store and organize everything you need to define your infrastructure with Chef Infra, including:
+This pattern uses the [chef-repo]({{< relref "/chef_repo" >}}) to store and organize everything you need to define your infrastructure with Chef Infra, including:
 
 - Cookbooks (including recipes, attributes, custom resources, libraries, and templates)
 - Data bags

--- a/docs-chef-io/content/effortless/quick_start.md
+++ b/docs-chef-io/content/effortless/quick_start.md
@@ -19,7 +19,7 @@ This is a quick guide on how to get started with Effortless.
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](https://www.habitat.sh/docs/install-habitat/)
+1. Install [Chef Habitat](/habitat/install_habitat/)
 1. Configure Chef Habitat on your workstation by running `hab setup`
 1. Clone the [Chef Effortless GitHub Repository](https://github.com/chef/effortless)
 

--- a/docs-chef-io/content/effortless/quick_start.md
+++ b/docs-chef-io/content/effortless/quick_start.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless Quick Start"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -10,8 +11,6 @@ draft = false
     weight = 10
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/quick_start.md)
-
 # Quick Start
 
 This is a quick guide on how to get started with Effortless.
@@ -19,7 +18,7 @@ This is a quick guide on how to get started with Effortless.
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat](/habitat/install_habitat/)
+1. Install [Chef Habitat]({{< relref "/habitat/install_habitat" >}})
 1. Configure Chef Habitat on your workstation by running `hab setup`
 1. Clone the [Chef Effortless GitHub Repository](https://github.com/chef/effortless)
 

--- a/docs-chef-io/content/effortless/variables_and_config.md
+++ b/docs-chef-io/content/effortless/variables_and_config.md
@@ -20,7 +20,7 @@ This documents the options for both your plan and your `habitat` configuration f
 
 ### Effortless Config Plan Variables
 
-You can use all the default plan variables shipped with Chef Habitat. Read more about [plan variables](https://www.habitat.sh/docs/reference/#plan-variables) in the Chef Habitat documentation.
+You can use all the default plan variables shipped with Chef Habitat. Read more about [plan variables](/habitat/plan_variables) in the Chef Habitat documentation.
 
 scaffold_chef_client
 : The Chef Habitat `chef-infra-client` package used. Change to use a different package. Default is `chef/chef-infra-client`

--- a/docs-chef-io/content/effortless/variables_and_config.md
+++ b/docs-chef-io/content/effortless/variables_and_config.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless Variables and Config"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -10,8 +11,6 @@ draft = false
     weight = 40
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/variables_and_config.md)
-
 # Plan Variables and Chef Habitat Configurations
 
 This documents the options for both your plan and your `habitat` configuration file.
@@ -20,7 +19,7 @@ This documents the options for both your plan and your `habitat` configuration f
 
 ### Effortless Config Plan Variables
 
-You can use all the default plan variables shipped with Chef Habitat. Read more about [plan variables](/habitat/plan_variables) in the Chef Habitat documentation.
+You can use all the default plan variables shipped with Chef Habitat. Read more about [plan variables]({{< relref "/habitat/plan_variables" >}}) in the Chef Habitat documentation.
 
 scaffold_chef_client
 : The Chef Habitat `chef-infra-client` package used. Change to use a different package. Default is `chef/chef-infra-client`
@@ -68,7 +67,7 @@ rubygems_url
 This configuration needs to be under the `[chef_license]` block in the .toml file.
 
 acceptance
-: Determines the Chef license acceptance at run time. Required for Chef Infra Client. See Chef License [here](https://docs.chef.io/chef_license_accept/#accepting-the-chef-license). Default is `undefined`
+: Determines the Chef license acceptance at run time. Required for Chef Infra Client. See Chef License [here]({{< relref "/chef_license_accept#accepting-the-chef-license" >}}). Default is `undefined`
 
 #### Effortless Config Chef Automate
 
@@ -129,7 +128,7 @@ log_level
 This configuration needs to be under the `[chef_license]` block in the .toml file.
 
 acceptance
-: Determines the Chef license acceptance at run time. This setting is required for chef-client to run successfully. See Chef License [here](https://docs.chef.io/chef_license_accept/#accepting-the-chef-license). Default is `undefined`
+: Determines the Chef license acceptance at run time. This setting is required for chef-client to run successfully. See Chef License [here]({{< relref "/chef_license_accept#accepting-the-chef-license" >}}). Default is `undefined`
 
 #### Effortless Audit Chef Automate
 

--- a/docs-chef-io/content/effortless/what_is_scaffolding.md
+++ b/docs-chef-io/content/effortless/what_is_scaffolding.md
@@ -1,6 +1,7 @@
 +++
 title = "Effortless What is Scaffolding"
 draft = false
+gh_repo = "effortless"
 
 [menu]
   [menu.effortless]
@@ -10,11 +11,9 @@ draft = false
     weight = 50
 +++
 
-[\[edit on GitHub\]](https://github.com/chef/effortless/blob/master/docs-chef-io/content/effortless/what_is_scaffolding.md)
-
 # Chef Habitat Scaffolding
 
-Chef Habitat scaffolding is a way to build a Chef Habitat plan that overrides some of the default functions that Chef Habitat uses during its build process. You can find out more about [scaffolding](/habitat/scaffolding/) in the Chef Habitat documentation.
+Chef Habitat scaffolding is a way to build a Chef Habitat plan that overrides some of the default functions that Chef Habitat uses during its build process. You can find out more about [scaffolding]({{< relref "/habitat/scaffolding" >}}) in the Chef Habitat documentation.
 
 ## Why The Effortless Pattern Uses Scaffolding
 

--- a/docs-chef-io/content/effortless/what_is_scaffolding.md
+++ b/docs-chef-io/content/effortless/what_is_scaffolding.md
@@ -14,7 +14,7 @@ draft = false
 
 # Chef Habitat Scaffolding
 
-Chef Habitat scaffolding is a way to build a Chef Habitat plan that overrides some of the default functions that Chef Habitat uses during its build process. You can find out more about [scaffolding](https://www.habitat.sh/docs/glossary/#sts=Scaffolding) in the Chef Habitat documentation.
+Chef Habitat scaffolding is a way to build a Chef Habitat plan that overrides some of the default functions that Chef Habitat uses during its build process. You can find out more about [scaffolding](/habitat/scaffolding/) in the Chef Habitat documentation.
 
 ## Why The Effortless Pattern Uses Scaffolding
 


### PR DESCRIPTION
This fixes a bunch of links:

- Edit on GitHub links are now generated with a partial
- Links that went to the old Habitat site are now corrected
- All relative links are generated with relref.

chef/chef-web-docs#2775 
chef/chef-web-docs#2877