### PR TITLE
Remove step from Effortless Environment Set-up

### DIFF
--- a/docs-chef-io/content/effortless/quick_start.md
+++ b/docs-chef-io/content/effortless/quick_start.md
@@ -18,7 +18,6 @@ This is a quick guide on how to get started with Effortless.
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Install [Chef Habitat]({{< relref "/habitat/install_habitat" >}})
 1. Configure Chef Habitat on your workstation by running `hab setup`
 1. Clone the [Chef Effortless GitHub Repository](https://github.com/chef/effortless)
 


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

This removes the Install Chef Habitat step from quick_start.md based on feedback in chef/chef-web-docs#2912