### PR TITLE
add metadata to every page in docs.chef.io/effortless/

### DIFF
--- a/docs-chef-io/content/effortless/_index.md
+++ b/docs-chef-io/content/effortless/_index.md
@@ -3,6 +3,9 @@ title = "Effortless Overview"
 draft = false
 gh_repo = "effortless"
 
+[cascade]
+  product = ["infra", "client", "server", "inspec", "habitat", "automate"]
+
 [menu]
   [menu.effortless]
     title = "Effortless Overview"


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Add product metadata to every page in docs.chef.io/effortless/
We can use this to facet search results

I'm not sure if this should specify "infra", "client", "server" or just "client" and "server", but we can always pull things later if we don't need them.

chef/chef-web-docs#2878