### PR TITLE
Change `hab setup` quick start docs ref to `hab cli setup`

### DIFF
--- a/docs-chef-io/content/effortless/quick_start.md
+++ b/docs-chef-io/content/effortless/quick_start.md
@@ -18,7 +18,7 @@ This is a quick guide on how to get started with Effortless.
 ## Effortless Environment Set-up
 
 1. Install [Chef Workstation](https://downloads.chef.io/chef-workstation)
-1. Configure Chef Habitat on your workstation by running `hab setup`
+1. Configure Chef Habitat on your workstation by running `hab cli setup`
 1. Clone the [Chef Effortless GitHub Repository](https://github.com/chef/effortless)
 
 ## Effortless Config Quick Start Pattern


### PR DESCRIPTION
I believe this should be changed given that `hab setup` throws a warning when used:
```
$ hab setup
Ø 'hab setup' as an alias for 'hab cli setup' is deprecated. Please update your automation and processes accordingly.

Habitat CLI Setup
=================

  Welcome to hab setup. Let's get started.

...
```

