### PR TITLE
INFC-233 Fix ruby syntax on ||= on empty string

### DIFF
--- a/scaffolding-chef-infra/lib/linux/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/linux/client-chunk.rb
@@ -1,17 +1,17 @@
 cfg_env_path_prefix = '{{cfg.env_path_prefix}}'
-cfg_env_path_prefix ||= '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin'
+cfg_env_path_prefix = '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin' if cfg_env_path_prefix.empty?
 ENV['PATH'] = "#{cfg_env_path_prefix}:#{ENV['PATH']}"
 
 cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
-cfg_ssl_verify_mode ||= ':verify_peer'
+cfg_ssl_verify_mode = ':verify_peer' if cfg_ssl_verify_mode.empty?
 ssl_verify_mode "#{cfg_ssl_verify_mode}"
 
 cfg_rubygems_url = '{{cfg.rubygems_url}}'
-cfg_rubygems_url ||= "https://www.rubygems.org"
+cfg_rubygems_url = "https://www.rubygems.org" if cfg_rubygems_url.empty?
 rubygems_url "#{cfg_rubygems_url}"
 
 cfg_verify_api_cert = '{{cfg.verify_api_cert}}'
-cfg_verify_api_cert ||= false
+cfg_verify_api_cert = false if cfg_verify_api_cert.empty?
 verify_api_cert "#{cfg_verify_api_cert}"
 
 {{#if cfg.automate.enable ~}}

--- a/scaffolding-chef-infra/lib/windows/client-chunk.rb
+++ b/scaffolding-chef-infra/lib/windows/client-chunk.rb
@@ -3,19 +3,19 @@ node_path '{{pkg.svc_data_path}}/nodes'
 role_path '{{pkg.svc_data_path}}/roles'
 
 cfg_env_path_prefix = '{{cfg.env_path_prefix}}'
-cfg_env_path_prefix ||= ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin"
+cfg_env_path_prefix = ";C:/WINDOWS;C:/WINDOWS/system32/;C:/WINDOWS/system32/WindowsPowerShell/v1.0;C:/ProgramData/chocolatey/bin" if cfg_env_path_prefix.empty?
 ENV['PATH'] += cfg_env_path_prefix
 
 cfg_ssl_verify_mode = '{{cfg.ssl_verify_mode}}'
-cfg_ssl_verify_mode ||= ":verify_peer"
+cfg_ssl_verify_mode = ":verify_peer" if cfg_ssl_verify_mode.empty?
 ssl_verify_mode "#{cfg_ssl_verify_mode}"
 
 cfg_rubygems_url = '{{cfg.rubygems_url}}'
-cfg_rubygems_url ||= "https://www.rubygems.org"
+cfg_rubygems_url = "https://www.rubygems.org" if cfg_rubygems_url.empty?
 rubygems_url "#{cfg_rubygems_url}"
 
 cfg_verify_api_cert = '{{cfg.verify_api_cert}}'
-cfg_verify_api_cert ||= false
+cfg_verify_api_cert = false if cfg_verify_api_cert.empty?
 verify_api_cert "#{cfg_verify_api_cert}"
 
 {{#if cfg.automate.enable ~}}


### PR DESCRIPTION
Applies the same fix as here https://github.com/chef/effortless/commit/2398397721a2ce0e6c11245c1355efe288076822 but also for the Linux version and also probably handles uninitialized `cfg` values. 

Signed-off-by: Thomas Powell <powell@progress.com>

