### PR TITLE
CHEF-30498 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,6 @@ If you are new to the `Effortless` pattern checkout some of the below examples a
 
 1. [Effortless Audit](examples/effortless_audit/Readme.md)
 1. [Effortless Config](examples/effortless_config/Readme.md)
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/scaffolding-chef-inspec/tests/windows/user-a2-profile-dep/inspec.yml
+++ b/scaffolding-chef-inspec/tests/windows/user-a2-profile-dep/inspec.yml
@@ -1,7 +1,7 @@
 name: stig-testing-audit
 title: Effortless stig testing Audit
 maintainer: humans@habitat.sh
-copyright: Chef Software Inc.
+copyright: Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 copyright_email: humans@habitat.sh
 license: Apache-2.0
 summary: Effortless Audit Windows Baseline

--- a/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/inspec.yml
+++ b/scaffolding-chef-inspec/tests/windows/user-git-profile-dep/inspec.yml
@@ -1,7 +1,7 @@
 name: windows-audit
 title: Effortless Windows Audit
 maintainer: humans@habitat.sh
-copyright: Chef Software Inc.
+copyright: Copyright (c) 2019-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 copyright_email: humans@habitat.sh
 license: Apache-2.0
 summary: Effortless Audit Windows Baseline


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2019-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
